### PR TITLE
Production hardening: fix critical bugs and improve error handling

### DIFF
--- a/.github/workflows/deploy-local-no-attestation.yml
+++ b/.github/workflows/deploy-local-no-attestation.yml
@@ -1,0 +1,127 @@
+name: Deploy without Verification
+on:
+    workflow_dispatch: # Manual trigger only - disabled by default
+
+permissions:
+    contents: write
+    id-token: write
+    attestations: write
+
+jobs:
+    build-and-deploy:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+
+            # Reproducible build in Docker
+            - name: Build in Docker
+              run: |
+                  docker build -f Dockerfile.build -t builder .
+                  docker create --name temp builder
+                  docker cp temp:/build/crates/rusty-safe/dist .
+                  docker rm temp
+
+            # Generate WASM hash
+            - name: Generate Hash
+              id: hash
+              run: |
+                  WASM_FILE=$(ls dist/*.wasm)
+                  HASH=$(sha256sum $WASM_FILE | awk '{print $1}')
+                  echo "wasm_hash=$HASH" >> $GITHUB_OUTPUT
+                  echo "$HASH" > dist/WASM_HASH.txt
+                  echo "**WASM File**: \`$(basename $WASM_FILE)\`" > dist/BUILD_INFO.txt
+                  echo "**WASM SHA256**: \`$HASH\`" >> dist/BUILD_INFO.txt
+                  echo "**Commit**: ${{ github.sha }}" >> dist/BUILD_INFO.txt
+                  echo "**Build Time**: $(date -u +%Y-%m-%dT%H:%M:%SZ)" >> dist/BUILD_INFO.txt
+
+            # GitHub attestation (cryptographic proof)
+            - name: Attest Build
+              if: ${{ !env.ACT }}
+              uses: actions/attest-build-provenance@v1
+              with:
+                  subject-path: "dist/*.wasm"
+
+            # Deploy to Cloudflare Pages
+            - name: Deploy to Cloudflare Pages
+              uses: cloudflare/pages-action@v1
+              with:
+                  apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+                  accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+                  projectName: rusty-safe
+                  directory: dist
+
+            # Pin to IPFS (Pinata)
+            - name: Pin to IPFS (Pinata)
+              id: ipfs
+              run: |
+                  # Use find to build the -F arguments for each file in the dist directory
+                  # This ensures Pinata reconstructs the directory structure correctly
+                  FILES_ARGS=$(find dist -type f -printf "-F file=@%p;filename=dist/%P ")
+
+                  # Upload to Pinata
+                  RESPONSE=$(curl -s -X POST "https://api.pinata.cloud/pinning/pinFileToIPFS" \
+                    -H "pinata_api_key: ${{ secrets.PINATA_API_KEY }}" \
+                    -H "pinata_secret_api_key: ${{ secrets.PINATA_SECRET_API_KEY }}" \
+                    $FILES_ARGS \
+                    -F 'pinataOptions={"cidVersion": 1}' \
+                    -F 'pinataMetadata={"name": "rusty-safe-${{ github.sha }}"}')
+
+                  CID=$(echo $RESPONSE | jq -r '.IpfsHash')
+
+                  if [ "$CID" = "null" ] || [ -z "$CID" ]; then
+                    echo "Error: Pinata upload failed"
+                    echo "Response: $RESPONSE"
+                    exit 1
+                  fi
+
+                  echo "cid=$CID" >> $GITHUB_OUTPUT
+                  echo "IPFS CID: $CID"
+
+            # Update DNSLink on Cloudflare
+            - name: Update DNSLink
+              run: |
+                  RECORD_NAME="_dnslink.rustysafe.com"
+                  EXISTING=$(curl -s -X GET "https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_ZONE_ID }}/dns_records?type=TXT&name=$RECORD_NAME" \
+                    -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
+                    -H "Content-Type: application/json")
+
+                  RECORD_ID=$(echo $EXISTING | jq -r '.result[0].id // empty')
+                  DNSLINK_VALUE="dnslink=/ipfs/${{ steps.ipfs.outputs.cid }}"
+
+                  if [ -n "$RECORD_ID" ]; then
+                    # Update existing record
+                    curl -s -X PUT "https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_ZONE_ID }}/dns_records/$RECORD_ID" \
+                      -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
+                      -H "Content-Type: application/json" \
+                      --data "{\"type\":\"TXT\",\"name\":\"$RECORD_NAME\",\"content\":\"$DNSLINK_VALUE\",\"ttl\":300}"
+                  else
+                    # Create new record
+                    curl -s -X POST "https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_ZONE_ID }}/dns_records" \
+                      -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
+                      -H "Content-Type: application/json" \
+                      --data "{\"type\":\"TXT\",\"name\":\"$RECORD_NAME\",\"content\":\"$DNSLINK_VALUE\",\"ttl\":300}"
+                  fi
+
+                  echo "DNSLink updated to: $DNSLINK_VALUE"
+
+            # Create release with hash (for tagged releases)
+            - name: Create Release
+              if: startsWith(github.ref, 'refs/tags/')
+              uses: softprops/action-gh-release@v1
+              with:
+                  files: |
+                      dist/WASM_HASH.txt
+                      dist/BUILD_INFO.txt
+                  body: |
+                      ## Build Verification
+                      **WASM Hash**: `${{ steps.hash.outputs.wasm_hash }}`
+
+                      ### Verify Deployment
+                      ```bash
+                      # Download deployed WASM
+                      curl -o app.wasm https://your-app.pages.dev/app.wasm
+
+                      # Check hash
+                      sha256sum app.wasm
+                      # Should match: ${{ steps.hash.outputs.wasm_hash }}
+                      ```

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,129 +1,129 @@
 name: Deploy with Verification
 on:
-  push:
-    branches: [main]
-  release:
-    types: [published]
+    push:
+        branches: [main]
+    release:
+        types: [published]
 
 permissions:
-  contents: write
-  id-token: write
-  attestations: write
+    contents: write
+    id-token: write
+    attestations: write
 
 jobs:
-  build-and-deploy:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      
-      # Reproducible build in Docker
-      - name: Build in Docker
-        run: |
-          docker build -f Dockerfile.build -t builder .
-          docker create --name temp builder
-          docker cp temp:/build/crates/rusty-safe/dist .
-          docker rm temp
-      
-      # Generate WASM hash
-      - name: Generate Hash
-        id: hash
-        run: |
-          WASM_FILE=$(ls dist/*.wasm)
-          HASH=$(sha256sum $WASM_FILE | awk '{print $1}')
-          echo "wasm_hash=$HASH" >> $GITHUB_OUTPUT
-          echo "$HASH" > dist/WASM_HASH.txt
-          echo "**WASM File**: \`$(basename $WASM_FILE)\`" > dist/BUILD_INFO.txt
-          echo "**WASM SHA256**: \`$HASH\`" >> dist/BUILD_INFO.txt
-          echo "**Commit**: ${{ github.sha }}" >> dist/BUILD_INFO.txt
-          echo "**Build Time**: $(date -u +%Y-%m-%dT%H:%M:%SZ)" >> dist/BUILD_INFO.txt
-      
-      # GitHub attestation (cryptographic proof)
-      - name: Attest Build
-        uses: actions/attest-build-provenance@v1
-        with:
-          subject-path: 'dist/*.wasm'
-      
-      # Deploy to Cloudflare Pages
-      - name: Deploy to Cloudflare Pages
-        uses: cloudflare/pages-action@v1
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          projectName: rusty-safe
-          directory: dist
-      
-      # Pin to IPFS (Pinata)
-      - name: Pin to IPFS (Pinata)
-        id: ipfs
-        run: |
-          # Use find to build the -F arguments for each file in the dist directory
-          # This ensures Pinata reconstructs the directory structure correctly
-          FILES_ARGS=$(find dist -type f -printf "-F file=@%p;filename=dist/%P ")
-          
-          # Upload to Pinata
-          RESPONSE=$(curl -s -X POST "https://api.pinata.cloud/pinning/pinFileToIPFS" \
-            -H "pinata_api_key: ${{ secrets.PINATA_API_KEY }}" \
-            -H "pinata_secret_api_key: ${{ secrets.PINATA_SECRET_API_KEY }}" \
-            $FILES_ARGS \
-            -F 'pinataOptions={"cidVersion": 1}' \
-            -F 'pinataMetadata={"name": "rusty-safe-${{ github.sha }}"}')
-          
-          CID=$(echo $RESPONSE | jq -r '.IpfsHash')
-          
-          if [ "$CID" = "null" ] || [ -z "$CID" ]; then
-            echo "Error: Pinata upload failed"
-            echo "Response: $RESPONSE"
-            exit 1
-          fi
-          
-          echo "cid=$CID" >> $GITHUB_OUTPUT
-          echo "IPFS CID: $CID"
-      
-      # Update DNSLink on Cloudflare
-      - name: Update DNSLink
-        run: |
-          RECORD_NAME="_dnslink.rustysafe.com"
-          EXISTING=$(curl -s -X GET "https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_ZONE_ID }}/dns_records?type=TXT&name=$RECORD_NAME" \
-            -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
-            -H "Content-Type: application/json")
-          
-          RECORD_ID=$(echo $EXISTING | jq -r '.result[0].id // empty')
-          DNSLINK_VALUE="dnslink=/ipfs/${{ steps.ipfs.outputs.cid }}"
-          
-          if [ -n "$RECORD_ID" ]; then
-            # Update existing record
-            curl -s -X PUT "https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_ZONE_ID }}/dns_records/$RECORD_ID" \
-              -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
-              -H "Content-Type: application/json" \
-              --data "{\"type\":\"TXT\",\"name\":\"$RECORD_NAME\",\"content\":\"$DNSLINK_VALUE\",\"ttl\":300}"
-          else
-            # Create new record
-            curl -s -X POST "https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_ZONE_ID }}/dns_records" \
-              -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
-              -H "Content-Type: application/json" \
-              --data "{\"type\":\"TXT\",\"name\":\"$RECORD_NAME\",\"content\":\"$DNSLINK_VALUE\",\"ttl\":300}"
-          fi
-          
-          echo "DNSLink updated to: $DNSLINK_VALUE"
-      
-      # Create release with hash (for tagged releases)
-      - name: Create Release
-        if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@v1
-        with:
-          files: |
-            dist/WASM_HASH.txt
-            dist/BUILD_INFO.txt
-          body: |
-            ## Build Verification
-            **WASM Hash**: `${{ steps.hash.outputs.wasm_hash }}`
-            
-            ### Verify Deployment
-            ```bash
-            # Download deployed WASM
-            curl -o app.wasm https://your-app.pages.dev/app.wasm
-            
-            # Check hash
-            sha256sum app.wasm
-            # Should match: ${{ steps.hash.outputs.wasm_hash }}
-            ```
+    build-and-deploy:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+
+            # Reproducible build in Docker
+            - name: Build in Docker
+              run: |
+                  docker build -f Dockerfile.build -t builder .
+                  docker create --name temp builder
+                  docker cp temp:/build/crates/rusty-safe/dist .
+                  docker rm temp
+
+            # Generate WASM hash
+            - name: Generate Hash
+              id: hash
+              run: |
+                  WASM_FILE=$(ls dist/*.wasm)
+                  HASH=$(sha256sum $WASM_FILE | awk '{print $1}')
+                  echo "wasm_hash=$HASH" >> $GITHUB_OUTPUT
+                  echo "$HASH" > dist/WASM_HASH.txt
+                  echo "**WASM File**: \`$(basename $WASM_FILE)\`" > dist/BUILD_INFO.txt
+                  echo "**WASM SHA256**: \`$HASH\`" >> dist/BUILD_INFO.txt
+                  echo "**Commit**: ${{ github.sha }}" >> dist/BUILD_INFO.txt
+                  echo "**Build Time**: $(date -u +%Y-%m-%dT%H:%M:%SZ)" >> dist/BUILD_INFO.txt
+
+            # GitHub attestation (cryptographic proof)
+            - name: Attest Build
+              uses: actions/attest-build-provenance@v1
+              with:
+                  subject-path: "dist/*.wasm"
+
+            # Deploy to Cloudflare Pages
+            - name: Deploy to Cloudflare Pages
+              uses: cloudflare/pages-action@v1
+              with:
+                  apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+                  accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+                  projectName: rusty-safe
+                  directory: dist
+
+            # Pin to IPFS (Pinata)
+            - name: Pin to IPFS (Pinata)
+              id: ipfs
+              run: |
+                  # Use find to build the -F arguments for each file in the dist directory
+                  # This ensures Pinata reconstructs the directory structure correctly
+                  FILES_ARGS=$(find dist -type f -printf "-F file=@%p;filename=dist/%P ")
+
+                  # Upload to Pinata
+                  RESPONSE=$(curl -s -X POST "https://api.pinata.cloud/pinning/pinFileToIPFS" \
+                    -H "pinata_api_key: ${{ secrets.PINATA_API_KEY }}" \
+                    -H "pinata_secret_api_key: ${{ secrets.PINATA_SECRET_API_KEY }}" \
+                    $FILES_ARGS \
+                    -F 'pinataOptions={"cidVersion": 1}' \
+                    -F 'pinataMetadata={"name": "rusty-safe-${{ github.sha }}"}')
+
+                  CID=$(echo $RESPONSE | jq -r '.IpfsHash')
+
+                  if [ "$CID" = "null" ] || [ -z "$CID" ]; then
+                    echo "Error: Pinata upload failed"
+                    echo "Response: $RESPONSE"
+                    exit 1
+                  fi
+
+                  echo "cid=$CID" >> $GITHUB_OUTPUT
+                  echo "IPFS CID: $CID"
+
+            # Update DNSLink on Cloudflare
+            - name: Update DNSLink
+              run: |
+                  RECORD_NAME="_dnslink.rustysafe.com"
+                  EXISTING=$(curl -s -X GET "https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_ZONE_ID }}/dns_records?type=TXT&name=$RECORD_NAME" \
+                    -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
+                    -H "Content-Type: application/json")
+
+                  RECORD_ID=$(echo $EXISTING | jq -r '.result[0].id // empty')
+                  DNSLINK_VALUE="dnslink=/ipfs/${{ steps.ipfs.outputs.cid }}"
+
+                  if [ -n "$RECORD_ID" ]; then
+                    # Update existing record
+                    curl -s -X PUT "https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_ZONE_ID }}/dns_records/$RECORD_ID" \
+                      -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
+                      -H "Content-Type: application/json" \
+                      --data "{\"type\":\"TXT\",\"name\":\"$RECORD_NAME\",\"content\":\"$DNSLINK_VALUE\",\"ttl\":300}"
+                  else
+                    # Create new record
+                    curl -s -X POST "https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_ZONE_ID }}/dns_records" \
+                      -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
+                      -H "Content-Type: application/json" \
+                      --data "{\"type\":\"TXT\",\"name\":\"$RECORD_NAME\",\"content\":\"$DNSLINK_VALUE\",\"ttl\":300}"
+                  fi
+
+                  echo "DNSLink updated to: $DNSLINK_VALUE"
+
+            # Create release with hash (for tagged releases)
+            - name: Create Release
+              if: startsWith(github.ref, 'refs/tags/')
+              uses: softprops/action-gh-release@v1
+              with:
+                  files: |
+                      dist/WASM_HASH.txt
+                      dist/BUILD_INFO.txt
+                  body: |
+                      ## Build Verification
+                      **WASM Hash**: `${{ steps.hash.outputs.wasm_hash }}`
+
+                      ### Verify Deployment
+                      ```bash
+                      # Download deployed WASM
+                      curl -o app.wasm https://your-app.pages.dev/app.wasm
+
+                      # Check hash
+                      sha256sum app.wasm
+                      # Should match: ${{ steps.hash.outputs.wasm_hash }}
+                      ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,12 +179,25 @@ fn update(&mut self, ctx: &egui::Context) {
 
 ```rust
 /// Computes the Safe transaction hash for the given parameters.
-/// 
+///
 /// Uses EIP-712 structured hashing with the Safe domain separator.
 pub fn compute_safe_tx_hash(tx: &SafeTransaction, chain_id: u64) -> B256 {
     // ...
 }
 ```
+
+### Rust
+
+- Do NOT use unwraps or anything that can panic in Rust code, handle errors. Obviously in tests unwraps and panics are fine!
+- In Rust code I prefer using `crate::` to `super::`; please don't use `super::`. If you see a lingering `super::` from someone else clean it up.
+- Avoid `pub use` on imports unless you are re-exposing a dependency so downstream consumers do not have to depend on it directly.
+- Skip global state via `lazy_static!`, `Once`, or similar; prefer passing explicit context structs for any shared state.
+
+#### Rust Workflow Checklist
+
+1. Run `cargo fmt`.
+1. Run `cargo clippy --all --benches --tests --examples --all-features` and address warnings.
+1. Execute the relevant `cargo test` or `just` targets to cover unit and end-to-end paths.
 
 ## Testing Guidelines
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4801,7 +4801,7 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 [[package]]
 name = "safe-hash"
 version = "0.0.19"
-source = "git+https://github.com/pripatelUK/safe-hash-rs?branch=main#9426be19efd34449b62ea1fc9fae567ebf49701d"
+source = "git+https://github.com/pripatelUK/safe-hash-rs?rev=9426be19efd34449b62ea1fc9fae567ebf49701d#9426be19efd34449b62ea1fc9fae567ebf49701d"
 dependencies = [
  "alloy",
  "reqwest",
@@ -4814,7 +4814,7 @@ dependencies = [
 [[package]]
 name = "safe-utils"
 version = "0.0.19"
-source = "git+https://github.com/pripatelUK/safe-hash-rs?branch=main#9426be19efd34449b62ea1fc9fae567ebf49701d"
+source = "git+https://github.com/pripatelUK/safe-hash-rs?rev=9426be19efd34449b62ea1fc9fae567ebf49701d#9426be19efd34449b62ea1fc9fae567ebf49701d"
 dependencies = [
  "alloy",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,9 @@ eframe = { version = "0.29", default-features = false, features = [
 egui = "0.29"
 egui_extras = { version = "0.29", features = ["image"] }
 
-# Safe hash computation from safe-hash-rs
-safe-utils = { git = "https://github.com/pripatelUK/safe-hash-rs", branch = "main" }
-safe-hash = { git = "https://github.com/pripatelUK/safe-hash-rs", branch = "main", default-features = false }
+# Safe hash computation from safe-hash-rs (pinned to specific commit for reproducible builds)
+safe-utils = { git = "https://github.com/pripatelUK/safe-hash-rs", rev = "9426be19efd34449b62ea1fc9fae567ebf49701d" }
+safe-hash = { git = "https://github.com/pripatelUK/safe-hash-rs", rev = "9426be19efd34449b62ea1fc9fae567ebf49701d", default-features = false }
 
 # Ethereum types (match safe-utils version)
 alloy = "0.11"

--- a/PRODUCTION_HARDENING.md
+++ b/PRODUCTION_HARDENING.md
@@ -1,0 +1,244 @@
+# Production Hardening Requirements
+
+This document outlines security findings and production hardening requirements for rusty-safe, a wallet-adjacent application for Safe{Wallet} transaction verification.
+
+**Current Security Posture:** HIGH RISK - Not Production Ready (6 issues fixed, 6 remaining)
+
+## Critical Issues (Must Fix Before Production)
+
+### 1. 4byte Signature Trust Model is Fundamentally Broken
+
+**Severity:** HIGH
+**Location:** `crates/rusty-safe/src/app.rs:1084-1093`, `crates/rusty-safe/src/decode/ui.rs:197,597`
+
+**Problem:** The "independent" calldata decoding is not actually independent - it trusts 4byte signatures from Sourcify and accepts the first signature that happens to decode successfully. This is vulnerable to:
+- **Selector collisions:** Different functions can have the same 4-byte selector
+- **Misleading ABIs:** An attacker could register a misleading signature for a malicious contract
+- **False confidence:** The UI presents this as "verified" when it's actually just a guess
+
+**Attack Vector:** A malicious actor could create a contract where a function like `transfer(address,uint256)` has a selector collision with `stealAllFunds(address,uint256)`. The 4byte lookup would return the benign-looking signature.
+
+**Remediation:**
+1. Treat 4byte signatures as **untrusted hints**, not verification
+2. Show ALL candidate signatures when multiple exist (with explicit ambiguity warnings)
+3. Require user acknowledgment when multiple signatures decode successfully
+4. Integrate with Sourcify full contract verification API for verified contracts
+5. Update UI labels from "Verified" to "Decoded (unverified)" or similar
+
+### ~~2. Message Hash Ignores Hex Flag~~ FIXED
+
+**Severity:** HIGH
+**Location:** `crates/rusty-safe/src/app.rs:780`
+**Status:** FIXED in commit `8186a2b`
+
+**Problem:** The `compute_message_hash` function ignored `self.msg_state.is_hex` flag, always treating input as UTF-8 string.
+
+**Resolution:** Now checks `is_hex` flag and parses input as hex bytes when enabled, using `MessageHasher::new_from_bytes()` with proper keccak256 hashing. Invalid hex input returns a descriptive error.
+
+### ~~3. Missing UI Repaint After Decode Lookup~~ FIXED
+
+**Severity:** MEDIUM
+**Location:** `crates/rusty-safe/src/app.rs:1023-1051`
+**Status:** FIXED in commit `2029448`
+
+**Problem:** `trigger_decode_lookup` spawned async work but never called `ctx.request_repaint()`.
+
+**Resolution:** Added `ctx: &egui::Context` parameter, cloned context into async blocks, and added `ctx.request_repaint()` after setting results in both WASM and native paths.
+
+---
+
+## Medium Severity Issues
+
+### 4. Signature Cache Has No Integrity Checking
+
+**Severity:** MEDIUM
+**Location:** `crates/rusty-safe/src/decode/sourcify.rs:97-136`
+
+**Problem:** The signature cache is loaded from eframe storage (localStorage in WASM) without any integrity or provenance checks. A compromised browser extension or XSS attack could inject malicious signatures.
+
+**Attack Vector:** Attacker injects cache entry mapping a benign selector to a misleading signature, causing users to misinterpret transaction intent.
+
+**Remediation:**
+1. Add HMAC or signature verification for cache entries
+2. Store source, timestamp, and hash for cache entries
+3. Clear cache on version changes
+4. Consider disabling persistent caching in production builds
+5. Add "cache provenance unknown" warning in UI
+
+### ~~5. Expected Value Validation Silently Skips Invalid Inputs~~ FIXED
+
+**Severity:** MEDIUM
+**Location:** `crates/rusty-safe/src/expected.rs:170,184`
+**Status:** FIXED in commit `d12e26a`
+
+**Problem:** When user entered invalid expected values, validation silently skipped and could return false "Match".
+
+**Resolution:** Added `ValidationResult::ParseErrors` variant. Validation now reports all parse errors explicitly in UI with yellow warning styling. Never returns "Match" if any field failed to parse.
+
+### ~~6. Warning Computation Coerces Parse Failures to Zero~~ FIXED
+
+**Severity:** MEDIUM
+**Location:** `crates/rusty-safe/src/hasher.rs:245-251,280-285`
+**Status:** FIXED in commit `d12e26a`
+
+**Problem:** `get_warnings_for_tx` and `get_warnings_from_api_tx` used `.unwrap_or(...)` to coerce parse failures to zero values, suppressing warnings.
+
+**Resolution:** Both functions now return `Result<SafeWarnings>`. Parse errors are propagated and tracked via `warnings_error` field in UI state. Callers display appropriate error messages instead of computing warnings on invalid data.
+
+### 7. Supply Chain Risk: Unpinned Git Dependencies
+
+**Severity:** MEDIUM
+**Location:** `Cargo.toml:23-24`
+
+**Problem:** `safe-utils` and `safe-hash` are pulled from `main` branch without commit pinning. Hash computation behavior could change unexpectedly across builds.
+
+**Impact:** Builds at different times could produce different hash results, or a compromised upstream could inject malicious code.
+
+**Remediation:**
+```toml
+# Pin to specific commit
+safe-utils = { git = "https://github.com/pripatelUK/safe-hash-rs", rev = "abc123..." }
+safe-hash = { git = "https://github.com/pripatelUK/safe-hash-rs", rev = "abc123...", default-features = false }
+```
+
+Also:
+1. Audit and vendor dependencies in release builds
+2. Enforce `Cargo.lock` in production pipelines
+3. Set up dependency update notifications
+
+### ~~8. Integer Comparison Truncates Large Values~~ FIXED
+
+**Severity:** MEDIUM
+**Location:** `crates/rusty-safe/src/decode/compare.rs:125-145`
+**Status:** FIXED in commit `88edf2a`
+
+**Problem:** `normalize_int` used `u128` which truncated values > 2^128, causing false mismatch reports.
+
+**Resolution:** Updated `normalize_int` to use `alloy::primitives::U256` for full uint256 range support. Unparseable values fall through to lowercase string comparison, preserving error context in mismatch reports. Added tests for 2^128 and max uint256 values.
+
+---
+
+## Low Severity Issues
+
+### 9. MultiSend Header Shows Unverified API Data
+
+**Severity:** LOW
+**Location:** `crates/rusty-safe/src/decode/ui.rs:381,385`
+
+**Problem:** MultiSend transaction headers display API-decoded method/params before verification completes. Could mislead users.
+
+**Remediation:** Label API-derived fields as "(unverified)" until local decode succeeds; prefer local decode display when available.
+
+### ~~10. Mutex Unwraps Can Panic~~ FIXED
+
+**Severity:** LOW
+**Location:** `crates/rusty-safe/src/app.rs`, `crates/rusty-safe/src/decode/sourcify.rs`
+**Status:** FIXED in commit `6d97a84`
+
+**Problem:** Multiple `.lock().unwrap()` calls would panic on poisoned locks.
+
+**Resolution:** Added `lock_or_recover!` macro that handles poisoned mutexes gracefully. If a thread panicked while holding a lock, the app now recovers the inner data via `poisoned.into_inner()` and logs a warning. Replaced 20 occurrences across app.rs (14) and sourcify.rs (6).
+
+### 11. Non-Checksummed Addresses Accepted Without Warning
+
+**Severity:** LOW
+**Location:** `crates/rusty-safe/src/state.rs:93-106`
+
+**Problem:** All-lowercase addresses are treated as valid. Typos in lowercase addresses won't be caught by checksum validation.
+
+**Remediation:** Show warning when address is not checksummed but could be (i.e., contains letters). Recommend using checksummed addresses.
+
+### 12. Empty Nested Calldata Shows "Pending" Instead of "Verified"
+
+**Severity:** LOW
+**Location:** `crates/rusty-safe/src/decode/verify.rs`
+
+**Problem:** Transactions with empty calldata (native ETH transfers) in MultiSend show "Pending" status instead of being marked as verified.
+
+**Remediation:** Explicitly handle empty calldata case and mark as "Verified - Native Transfer".
+
+---
+
+## Edge Cases Requiring Special Handling
+
+### Hash Computation Edge Cases
+- **Safe version mismatch:** User-selected version doesn't match actual Safe contract version
+- **Unsupported chain:** Chain not in safe-utils list
+- **API timeout during verification:** Should show "verification incomplete" not "verified"
+
+### Decoding Edge Cases
+- **Multiple valid signatures for selector:** Currently picks first; should show all
+- **Very long calldata:** May cause UI performance issues
+- **Malformed ABI encoding:** Should fail gracefully, not crash
+- **Recursive MultiSend:** MultiSend containing MultiSend calls
+
+### Input Validation Edge Cases
+- **Unicode in addresses:** Should be rejected
+- **Leading/trailing whitespace:** Currently handled inconsistently
+- **Scientific notation in values:** May parse incorrectly
+
+---
+
+## Security Architecture Recommendations
+
+### 1. Defense in Depth for Calldata Verification
+```
+Layer 1: Parse calldata structure (MultiSend vs single)
+Layer 2: 4byte signature lookup (HINT ONLY)
+Layer 3: Sourcify verified contract ABI (if available)
+Layer 4: User-provided expected values
+Layer 5: Visual diff highlighting
+```
+
+### 2. Trust Boundaries
+```
+UNTRUSTED:
+- Safe Transaction Service API responses
+- 4byte.directory / Sourcify signature database
+- User inputs
+- localStorage / eframe storage
+
+TRUSTED (after verification):
+- Computed hashes (from safe-utils)
+- EIP-712 structured data
+- Chain configuration (from safe-utils)
+```
+
+### 3. Error Handling Strategy
+```rust
+// Principle: Fail loudly, never silently succeed
+pub enum VerificationResult {
+    Verified { confidence: Confidence },
+    Mismatch { details: Vec<Mismatch> },
+    VerificationFailed { reason: String },  // <- Use this, don't silently pass
+    Pending,
+}
+
+pub enum Confidence {
+    High,    // Sourcify verified ABI + expected values match
+    Medium,  // 4byte decode matches API
+    Low,     // 4byte only, no API comparison
+    Unknown, // Decode failed
+}
+```
+
+---
+
+## Pre-Production Checklist
+
+- [ ] Fix all CRITICAL and HIGH severity issues (2/3 done: #2, #3 fixed; #1 remains)
+- [x] Fix MEDIUM severity issues #5, #6 (validation/warnings parse error handling)
+- [x] Fix MEDIUM severity issue #8 (uint256 comparison truncation)
+- [x] Fix LOW severity issue #10 (mutex unwraps can panic)
+- [ ] Address MEDIUM severity issues or document accepted risks
+- [ ] Pin all git dependencies to specific commits
+- [ ] Add comprehensive input validation
+- [ ] Implement cache integrity verification
+- [ ] Add "verification confidence" indicators to UI
+- [ ] Update all "verified" labels to accurately reflect trust level
+- [ ] Add security-focused user documentation
+- [ ] Conduct external security audit
+- [ ] Set up automated dependency vulnerability scanning
+- [ ] Implement telemetry for error tracking (opt-in)
+- [ ] Add rate limiting awareness for API calls
+- [ ] Test with adversarial inputs (fuzzing)

--- a/TEST_COVERAGE_REQUIREMENTS.md
+++ b/TEST_COVERAGE_REQUIREMENTS.md
@@ -1,0 +1,792 @@
+# Test Coverage Requirements
+
+This document specifies the test coverage requirements for rusty-safe to achieve production readiness. Given the wallet-adjacent nature of this application, comprehensive testing is essential.
+
+## Current Test Coverage Status
+
+**Existing Tests:**
+- `crates/rusty-safe/src/state.rs` - Address book CSV import/export tests
+- `crates/rusty-safe/src/decode/parser.rs` - Basic calldata decoding tests
+- `crates/rusty-safe/src/decode/sourcify.rs` - Selector normalization test
+
+**Coverage Gaps:**
+- No hash computation tests
+- No API response parsing tests
+- No expected value validation tests
+- No MultiSend parsing/verification tests
+- No UI component tests
+- No integration tests
+- No adversarial input tests
+
+---
+
+## Required Test Suites
+
+### 1. Hash Computation Tests (`crates/rusty-safe/src/hasher.rs`)
+
+**Priority:** CRITICAL
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Known test vectors from actual Safe transactions
+    #[test]
+    fn test_hash_computation_mainnet_v1_3() {
+        // Use known Safe transaction with verified hash
+        let hashes = compute_hashes(
+            "ethereum",
+            "0x...",  // Known Safe address
+            "1.3.0",
+            "0x...",  // to
+            "0",      // value
+            "0x...",  // data
+            0,        // operation
+            "0", "0", "0",
+            "0x0000000000000000000000000000000000000000",
+            "0x0000000000000000000000000000000000000000",
+            "0",
+        ).unwrap();
+
+        assert_eq!(hashes.safe_tx_hash, "0x...");  // Expected hash
+    }
+
+    #[test]
+    fn test_hash_computation_all_safe_versions() {
+        for version in ["1.0.0", "1.1.0", "1.1.1", "1.2.0", "1.3.0", "1.4.0", "1.4.1"] {
+            // Test each version produces valid (different) hashes
+        }
+    }
+
+    #[test]
+    fn test_hash_computation_all_supported_chains() {
+        // Test that each chain in safe_utils produces valid hashes
+    }
+
+    #[test]
+    fn test_invalid_chain_returns_error() {
+        let result = compute_hashes("invalid_chain", ...);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_invalid_address_returns_error() {
+        let result = compute_hashes("ethereum", "not_an_address", ...);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_invalid_hex_data_returns_error() {
+        let result = compute_hashes(..., "0xGGGG", ...);  // Invalid hex
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_odd_length_hex_data_returns_error() {
+        let result = compute_hashes(..., "0xabc", ...);  // Odd length
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_large_value_handling() {
+        // Test with value > u128::MAX
+        let result = compute_hashes(
+            ...,
+            "340282366920938463463374607431768211456",  // 2^128
+            ...
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_delegatecall_warning() {
+        let warnings = get_warnings_for_tx(..., 1, ...);  // operation = 1
+        assert!(warnings.delegatecall);
+    }
+
+    #[test]
+    fn test_dangerous_method_warning() {
+        // Test addOwnerWithThreshold, removeOwner, swapOwner, changeThreshold
+    }
+}
+```
+
+### 2. Calldata Decoding Tests (`crates/rusty-safe/src/decode/`)
+
+**Priority:** CRITICAL
+
+```rust
+// parser.rs tests
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ERC20 Functions
+    #[test]
+    fn test_decode_erc20_transfer() {
+        let data = "0xa9059cbb000000000000000000000000...";
+        let result = decode_with_signature(data, "transfer(address,uint256)");
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().method, "transfer");
+    }
+
+    #[test]
+    fn test_decode_erc20_approve() {
+        let data = "0x095ea7b3...";
+        let result = decode_with_signature(data, "approve(address,uint256)");
+        assert!(result.is_ok());
+    }
+
+    // MultiSend
+    #[test]
+    fn test_multisend_unpack_single_tx() {
+        let packed = hex::decode("00...").unwrap();
+        let txs = unpack_multisend_transactions(&packed).unwrap();
+        assert_eq!(txs.len(), 1);
+    }
+
+    #[test]
+    fn test_multisend_unpack_multiple_txs() {
+        // Known MultiSend with 5 transactions
+        let packed = hex::decode("...").unwrap();
+        let txs = unpack_multisend_transactions(&packed).unwrap();
+        assert_eq!(txs.len(), 5);
+    }
+
+    #[test]
+    fn test_multisend_truncated_data_error() {
+        let packed = hex::decode("00").unwrap();  // Incomplete
+        let result = unpack_multisend_transactions(&packed);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_multisend_empty_nested_calldata() {
+        // Native ETH transfer within MultiSend
+    }
+
+    // Edge cases
+    #[test]
+    fn test_decode_empty_calldata() {
+        let decoded = parse_initial("0x", None);
+        assert!(matches!(decoded.kind, TransactionKind::Empty));
+    }
+
+    #[test]
+    fn test_decode_short_calldata() {
+        let decoded = parse_initial("0xabcd", None);  // < 4 bytes
+        assert!(matches!(decoded.kind, TransactionKind::Unknown));
+    }
+
+    #[test]
+    fn test_selector_collision_handling() {
+        // Test selector that has multiple valid signatures
+        // Verify behavior is deterministic
+    }
+
+    #[test]
+    fn test_complex_tuple_decoding() {
+        // Zodiac scopeFunction with nested arrays
+        let sig = "scopeFunction(uint16,address,bytes4,bool[],uint8[],uint8[],bytes[],uint8)";
+        let data = "0x33a0480c...";
+        let result = decode_with_signature(data, sig);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_bytes4_formatting() {
+        // Ensure bytes4 is formatted as 0x + 8 chars, not full 32 bytes
+    }
+}
+
+// compare.rs tests
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_compare_matching_decodes() {
+        let api = ApiDecode { method: "transfer".into(), params: vec![...] };
+        let local = LocalDecode { method: "transfer".into(), params: vec![...] };
+        let result = compare_decodes(Some(&api), Some(&local));
+        assert!(matches!(result, ComparisonResult::Match));
+    }
+
+    #[test]
+    fn test_compare_method_mismatch() {
+        let api = ApiDecode { method: "transfer".into(), ... };
+        let local = LocalDecode { method: "approve".into(), ... };
+        let result = compare_decodes(Some(&api), Some(&local));
+        assert!(matches!(result, ComparisonResult::MethodMismatch { .. }));
+    }
+
+    #[test]
+    fn test_compare_param_mismatch() {
+        // Different parameter values
+    }
+
+    #[test]
+    fn test_compare_large_uint256_values() {
+        // Values > u128::MAX should still compare correctly
+        let api_val = "340282366920938463463374607431768211456";  // 2^128
+        let local_val = "340282366920938463463374607431768211456";
+        // Should match, not truncate
+    }
+
+    #[test]
+    fn test_compare_address_case_insensitive() {
+        // 0xAbC... should equal 0xabc...
+    }
+
+    #[test]
+    fn test_compare_only_api() {
+        let result = compare_decodes(Some(&api), None);
+        assert!(matches!(result, ComparisonResult::OnlyApi));
+    }
+
+    #[test]
+    fn test_compare_only_local() {
+        let result = compare_decodes(None, Some(&local));
+        assert!(matches!(result, ComparisonResult::OnlyLocal));
+    }
+}
+```
+
+### 3. Expected Value Validation Tests (`crates/rusty-safe/src/expected.rs`)
+
+**Priority:** HIGH
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_validate_matching_to_address() {
+        let tx = mock_safe_transaction("0xAbC...", "0", "0x", 0);
+        let expected = ExpectedState { to: "0xabc...".into(), ..Default::default() };
+        let result = validate_against_api(&tx, &expected);
+        assert!(result.mismatches.is_empty());
+    }
+
+    #[test]
+    fn test_validate_mismatched_to_address() {
+        let tx = mock_safe_transaction("0xAbC...", "0", "0x", 0);
+        let expected = ExpectedState { to: "0xDEF...".into(), ..Default::default() };
+        let result = validate_against_api(&tx, &expected);
+        assert!(!result.mismatches.is_empty());
+    }
+
+    #[test]
+    fn test_validate_invalid_expected_address_is_error() {
+        // Invalid expected address should produce an error, not silent skip
+        let expected = ExpectedState { to: "not_valid".into(), ..Default::default() };
+        // Should not silently return "Match"
+    }
+
+    #[test]
+    fn test_validate_value_wei() {
+        let tx = mock_safe_transaction(..., "1000000000000000000", ...);  // 1 ETH
+        let expected = ExpectedState { value: "1000000000000000000".into(), ... };
+        // Should match
+    }
+
+    #[test]
+    fn test_validate_value_mismatch() {
+        let tx = mock_safe_transaction(..., "1000000000000000000", ...);
+        let expected = ExpectedState { value: "2000000000000000000".into(), ... };
+        // Should report mismatch
+    }
+
+    #[test]
+    fn test_validate_data_prefix_match() {
+        let tx = mock_safe_transaction(..., "0xa9059cbb...", ...);
+        let expected = ExpectedState { data_prefix: "0xa9059cbb".into(), ... };
+        // Should match (prefix only)
+    }
+
+    #[test]
+    fn test_validate_operation_call() {
+        let tx = mock_safe_transaction(..., 0);  // Call
+        let expected = ExpectedState { operation: "0".into(), ... };
+        // Should match
+    }
+
+    #[test]
+    fn test_validate_operation_delegatecall() {
+        let tx = mock_safe_transaction(..., 1);  // DelegateCall
+        let expected = ExpectedState { operation: "1".into(), ... };
+        // Should match
+    }
+}
+```
+
+### 4. Address Validation Tests (`crates/rusty-safe/src/state.rs`)
+
+**Priority:** HIGH
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // EIP-55 Checksum Tests
+    #[test]
+    fn test_valid_checksummed_address() {
+        let result = validate_address("0x4F2083f5fBede34C2714aFfb3105539775f7FE64");
+        assert_eq!(result, AddressValidation::Valid);
+    }
+
+    #[test]
+    fn test_valid_lowercase_address() {
+        let result = validate_address("0x4f2083f5fbede34c2714affb3105539775f7fe64");
+        assert_eq!(result, AddressValidation::Valid);
+    }
+
+    #[test]
+    fn test_valid_uppercase_address() {
+        let result = validate_address("0x4F2083F5FBEDE34C2714AFFB3105539775F7FE64");
+        assert_eq!(result, AddressValidation::Valid);
+    }
+
+    #[test]
+    fn test_invalid_checksum() {
+        // Wrong case that doesn't match EIP-55
+        let result = validate_address("0x4F2083f5fbede34c2714affb3105539775f7fe64");
+        assert_eq!(result, AddressValidation::ChecksumMismatch);
+    }
+
+    #[test]
+    fn test_invalid_too_short() {
+        let result = validate_address("0x4F2083f5");
+        assert_eq!(result, AddressValidation::Invalid);
+    }
+
+    #[test]
+    fn test_invalid_too_long() {
+        let result = validate_address("0x4F2083f5fBede34C2714aFfb3105539775f7FE6400");
+        assert_eq!(result, AddressValidation::Invalid);
+    }
+
+    #[test]
+    fn test_invalid_no_prefix() {
+        let result = validate_address("4F2083f5fBede34C2714aFfb3105539775f7FE64");
+        assert_eq!(result, AddressValidation::Invalid);
+    }
+
+    #[test]
+    fn test_invalid_non_hex() {
+        let result = validate_address("0xGGGGGGf5fBede34C2714aFfb3105539775f7FE64");
+        assert_eq!(result, AddressValidation::Invalid);
+    }
+
+    #[test]
+    fn test_normalize_lowercase_to_checksummed() {
+        let normalized = normalize_address("0x4f2083f5fbede34c2714affb3105539775f7fe64");
+        assert_eq!(normalized, Some("0x4F2083f5fBede34C2714aFfb3105539775f7FE64".to_string()));
+    }
+
+    // Recent Addresses Tests
+    #[test]
+    fn test_recent_addresses_deduplication() {
+        let mut recent = vec!["0xAAA...".into()];
+        add_recent_address(&mut recent, "0xaaa...");  // Same address, different case
+        assert_eq!(recent.len(), 1);
+    }
+
+    #[test]
+    fn test_recent_addresses_max_limit() {
+        let mut recent = vec![];
+        for i in 0..15 {
+            add_recent_address(&mut recent, &format!("0x{:040x}", i));
+        }
+        assert_eq!(recent.len(), 10);  // MAX_RECENT_ADDRESSES
+    }
+
+    #[test]
+    fn test_recent_addresses_invalid_ignored() {
+        let mut recent = vec![];
+        add_recent_address(&mut recent, "invalid");
+        assert!(recent.is_empty());
+    }
+}
+```
+
+### 5. API Response Parsing Tests
+
+**Priority:** HIGH
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_safe_info_response() {
+        let json = r#"{
+            "address": "0x...",
+            "nonce": "42",
+            "threshold": 2,
+            "owners": ["0x...", "0x..."],
+            "modules": [],
+            "version": "1.3.0"
+        }"#;
+        let info: SafeInfo = serde_json::from_str(json).unwrap();
+        assert_eq!(info.nonce, 42);
+    }
+
+    #[test]
+    fn test_parse_safe_transaction_response() {
+        // Full Safe Transaction Service response
+    }
+
+    #[test]
+    fn test_parse_data_decoded_nested() {
+        // MultiSend with nested dataDecoded
+    }
+
+    #[test]
+    fn test_malformed_nonce_string() {
+        // nonce: "not_a_number" should fail gracefully
+    }
+
+    #[test]
+    fn test_missing_optional_fields() {
+        // Response without dataDecoded should still parse
+    }
+}
+```
+
+### 6. Signature Cache Tests (`crates/rusty-safe/src/decode/sourcify.rs`)
+
+**Priority:** MEDIUM
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cache_hit() {
+        let lookup = SignatureLookup::new();
+        // Pre-populate cache
+        lookup.cache.lock().unwrap().insert(
+            "0xa9059cbb".into(),
+            vec!["transfer(address,uint256)".into()],
+        );
+
+        let result = lookup.lookup("0xa9059cbb").await.unwrap();
+        assert_eq!(result, vec!["transfer(address,uint256)"]);
+    }
+
+    #[test]
+    fn test_spurious_detection() {
+        let lookup = SignatureLookup::new();
+        // Simulate 3 failures
+        for _ in 0..3 {
+            lookup.on_failure(&mock_timeout_error());
+        }
+        assert!(lookup.is_spurious());
+    }
+
+    #[test]
+    fn test_spurious_reset() {
+        let lookup = SignatureLookup::new();
+        lookup.is_spurious.store(true, Ordering::Relaxed);
+        lookup.reset_spurious();
+        assert!(!lookup.is_spurious());
+    }
+
+    #[test]
+    fn test_selector_normalization() {
+        assert_eq!(normalize_selector("0xA9059CBB"), "0xa9059cbb");
+        assert_eq!(normalize_selector("a9059cbb"), "0xa9059cbb");
+    }
+
+    #[test]
+    fn test_cache_max_size_enforcement() {
+        // Adding > MAX_CACHED_SELECTORS should truncate on save
+    }
+}
+```
+
+### 7. Integration Tests
+
+**Priority:** HIGH
+
+```rust
+// tests/integration_tests.rs
+
+#[tokio::test]
+async fn test_full_verification_flow_mainnet() {
+    // 1. Fetch known Safe transaction from API (use mock)
+    // 2. Compute hashes
+    // 3. Verify hash matches API
+    // 4. Decode calldata
+    // 5. Compare API vs local decode
+}
+
+#[tokio::test]
+async fn test_multisend_verification_flow() {
+    // Full MultiSend batch verification
+}
+
+#[tokio::test]
+async fn test_offline_mode_flow() {
+    // Manual input -> hash computation -> decode
+}
+
+#[tokio::test]
+async fn test_eip712_flow() {
+    // JSON input -> parse -> Safe wrap -> hash
+}
+
+#[tokio::test]
+async fn test_message_signing_flow() {
+    // Message -> hash -> Safe message hash
+}
+```
+
+### 8. Adversarial Input Tests
+
+**Priority:** HIGH (Security)
+
+```rust
+#[cfg(test)]
+mod adversarial_tests {
+    use super::*;
+
+    // Malformed Input Tests
+    #[test]
+    fn test_unicode_in_address() {
+        let result = validate_address("0x4F2083f5fBede34C2714aFfb3105539775f7FE6\u{200B}4");
+        assert_eq!(result, AddressValidation::Invalid);
+    }
+
+    #[test]
+    fn test_null_bytes_in_input() {
+        let data = "0xa9059cbb\0\0\0\0...";
+        // Should handle gracefully
+    }
+
+    #[test]
+    fn test_extremely_long_calldata() {
+        // 1MB of calldata
+        let data = format!("0x{}", "aa".repeat(500_000));
+        // Should not crash or hang
+    }
+
+    #[test]
+    fn test_deeply_nested_multisend() {
+        // MultiSend containing MultiSend
+    }
+
+    // Selector Collision Tests
+    #[test]
+    fn test_known_selector_collision() {
+        // transfer(address,uint256) collides with some other function
+        // Test that we handle ambiguity correctly
+    }
+
+    // Value Overflow Tests
+    #[test]
+    fn test_value_overflow_max_uint256() {
+        let max = "115792089237316195423570985008687907853269984665640564039457584007913129639935";
+        // Should handle without panic
+    }
+
+    // JSON Injection Tests
+    #[test]
+    fn test_malicious_json_in_eip712() {
+        let json = r#"{"types": {}, "__proto__": {"polluted": true}}"#;
+        // Should not cause issues
+    }
+
+    // CSV Injection Tests
+    #[test]
+    fn test_csv_formula_injection() {
+        let csv = "=CMD|'/C calc'!A0,name,1\n0x...,safe,1";
+        let mut book = AddressBook::default();
+        let result = book.import_csv(csv);
+        // Formula should be treated as invalid address
+    }
+}
+```
+
+---
+
+## Test Infrastructure Requirements
+
+### Mock Server Setup
+
+```rust
+// tests/common/mod.rs
+
+use wiremock::{MockServer, Mock, matchers::*, ResponseTemplate};
+
+pub async fn setup_mock_safe_api() -> MockServer {
+    let mock_server = MockServer::start().await;
+
+    // Mock Safe info endpoint
+    Mock::given(method("GET"))
+        .and(path_regex(r"/api/v1/safes/0x[a-fA-F0-9]{40}/"))
+        .respond_with(ResponseTemplate::new(200)
+            .set_body_json(mock_safe_info()))
+        .mount(&mock_server)
+        .await;
+
+    // Mock transactions endpoint
+    Mock::given(method("GET"))
+        .and(path_regex(r"/api/v1/safes/0x[a-fA-F0-9]{40}/multisig-transactions/"))
+        .respond_with(ResponseTemplate::new(200)
+            .set_body_json(mock_transactions()))
+        .mount(&mock_server)
+        .await;
+
+    mock_server
+}
+
+pub async fn setup_mock_sourcify_api() -> MockServer {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/signature-database/v1/lookup"))
+        .respond_with(ResponseTemplate::new(200)
+            .set_body_json(mock_signatures()))
+        .mount(&mock_server)
+        .await;
+
+    mock_server
+}
+```
+
+### Test Data Fixtures
+
+```rust
+// tests/fixtures/mod.rs
+
+/// Known Safe transaction with verified hash (Mainnet)
+pub const KNOWN_TX_MAINNET: &str = r#"{
+    "safe": "0x...",
+    "to": "0x...",
+    "value": "0",
+    "data": "0xa9059cbb...",
+    "operation": 0,
+    "safeTxGas": 0,
+    "baseGas": 0,
+    "gasPrice": "0",
+    "gasToken": "0x0000000000000000000000000000000000000000",
+    "refundReceiver": "0x0000000000000000000000000000000000000000",
+    "nonce": 42,
+    "safeTxHash": "0x..."
+}"#;
+
+/// MultiSend with 5 nested transactions
+pub const MULTISEND_5_TXS: &str = "0x8d80ff0a...";
+
+/// EIP-712 typed data example
+pub const EIP712_PERMIT: &str = r#"{
+    "types": {...},
+    "primaryType": "Permit",
+    "domain": {...},
+    "message": {...}
+}"#;
+```
+
+---
+
+## Coverage Targets
+
+| Module | Current | Target | Priority |
+|--------|---------|--------|----------|
+| `hasher.rs` | 0% | 90% | CRITICAL |
+| `decode/parser.rs` | 20% | 85% | CRITICAL |
+| `decode/compare.rs` | 0% | 90% | CRITICAL |
+| `expected.rs` | 0% | 85% | HIGH |
+| `state.rs` (validation) | 30% | 80% | HIGH |
+| `decode/sourcify.rs` | 5% | 70% | MEDIUM |
+| `decode/verify.rs` | 0% | 75% | HIGH |
+| `decode/offline.rs` | 0% | 70% | MEDIUM |
+| Integration tests | 0% | N/A | HIGH |
+| Adversarial tests | 0% | N/A | HIGH |
+
+**Overall Target:** 80% line coverage, 100% coverage of security-critical paths
+
+---
+
+## CI/CD Integration
+
+```yaml
+# .github/workflows/test.yml
+name: Tests
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-action@stable
+
+      - name: Run tests
+        run: cargo test --all-features
+
+      - name: Run tests with coverage
+        run: cargo llvm-cov --all-features --lcov --output-path lcov.info
+
+      - name: Upload coverage
+        uses: codecov/codecov-action@v3
+        with:
+          files: lcov.info
+          fail_ci_if_error: true
+
+      - name: Check coverage threshold
+        run: |
+          COVERAGE=$(cargo llvm-cov --all-features --summary-only | grep -oP '\d+\.\d+(?=%)')
+          if (( $(echo "$COVERAGE < 80" | bc -l) )); then
+            echo "Coverage $COVERAGE% is below 80% threshold"
+            exit 1
+          fi
+
+  fuzz:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install cargo-fuzz
+        run: cargo install cargo-fuzz
+
+      - name: Run fuzzer (limited)
+        run: cargo fuzz run calldata_parser -- -max_total_time=60
+```
+
+---
+
+## Fuzzing Targets
+
+```rust
+// fuzz/fuzz_targets/calldata_parser.rs
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+use rusty_safe::decode::parser::*;
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(s) = std::str::from_utf8(data) {
+        let _ = parse_initial(s, None);
+    }
+});
+
+// fuzz/fuzz_targets/address_validation.rs
+fuzz_target!(|data: &str| {
+    let _ = validate_address(data);
+});
+
+// fuzz/fuzz_targets/multisend_unpack.rs
+fuzz_target!(|data: &[u8]| {
+    let _ = unpack_multisend_transactions(data);
+});
+```

--- a/crates/rusty-safe/build.rs
+++ b/crates/rusty-safe/build.rs
@@ -6,14 +6,17 @@ fn main() {
         .args(&["rev-parse", "HEAD"])
         .output()
         .unwrap();
-        
+
     if !output.status.success() {
-        panic!("Failed to get git hash: {}", String::from_utf8_lossy(&output.stderr));
+        panic!(
+            "Failed to get git hash: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
     }
-    
+
     let git_hash = String::from_utf8(output.stdout).unwrap();
     println!("cargo:rustc-env=GIT_HASH={}", git_hash.trim());
-    
+
     // Embed build time
     let build_time = chrono::Utc::now().to_rfc3339();
     println!("cargo:rustc-env=BUILD_TIME={}", build_time);

--- a/crates/rusty-safe/src/api.rs
+++ b/crates/rusty-safe/src/api.rs
@@ -4,13 +4,12 @@
 
 // Re-export API types from safe-hash
 pub use safe_hash::{
-    SafeTransaction, SafeApiResponse, Confirmation, DataDecoded, Parameter, Mismatch,
-    get_safe_transaction_async,
-    validate_safe_tx_hash,
+    get_safe_transaction_async, validate_safe_tx_hash, Confirmation, DataDecoded, Mismatch,
+    Parameter, SafeApiResponse, SafeTransaction,
 };
 
 // Re-export hash types
-pub use safe_hash::{TxInput, tx_signing_hashes, SafeHashes};
+pub use safe_hash::{tx_signing_hashes, SafeHashes, TxInput};
 
 // Re-export warning check
 pub use safe_hash::{check_suspicious_content, SafeWarnings};

--- a/crates/rusty-safe/src/app.rs
+++ b/crates/rusty-safe/src/app.rs
@@ -435,9 +435,14 @@ impl App {
         // Expected values validation result (before other warnings)
         expected::render_result(ui, &self.tx_state.expected);
 
-        if self.tx_state.warnings.has_warnings() {
+        let warnings_error = self.tx_state.warnings_error.as_deref();
+        if self.tx_state.warnings.has_warnings() || warnings_error.is_some() {
             ui.add_space(15.0);
             ui::section_header(ui, "⚠️ Warnings");
+
+            if let Some(error) = warnings_error {
+                ui::error_message(ui, &format!("Warning computation failed: {}", error));
+            }
 
             let w = &self.tx_state.warnings;
             if w.delegatecall {
@@ -1321,8 +1326,13 @@ impl App {
             ui.add_space(10.0);
             
             // Warnings
-            if self.offline_state.warnings.has_warnings() {
+            let warnings_error = self.offline_state.warnings_error.as_deref();
+            if self.offline_state.warnings.has_warnings() || warnings_error.is_some() {
                 ui::section_header(ui, "⚠️ Warnings");
+
+                if let Some(error) = warnings_error {
+                    ui::error_message(ui, &format!("Warning computation failed: {}", error));
+                }
                 
                 let w = &self.offline_state.warnings;
                 if w.delegatecall {

--- a/crates/rusty-safe/src/app.rs
+++ b/crates/rusty-safe/src/app.rs
@@ -930,7 +930,7 @@ impl App {
                         match kind {
                             "single" => {
                                 debug_log!("Triggering 4byte lookup for selector: {}", selector);
-                                self.trigger_decode_lookup(&selector, &data);
+                                self.trigger_decode_lookup(ctx, &selector, &data);
                             }
                             "multi" => {
                                 debug_log!("Triggering bulk verification for {} transactions", tx_count);
@@ -1020,11 +1020,12 @@ impl App {
         }
     }
 
-    fn trigger_decode_lookup(&self, selector: &str, data: &str) {
+    fn trigger_decode_lookup(&self, ctx: &egui::Context, selector: &str, data: &str) {
         let lookup = self.signature_lookup.clone();
         let selector = selector.to_string();
         let data = data.to_string();
         let result = Arc::clone(&self.decode_result);
+        let ctx = ctx.clone();
 
         #[cfg(target_arch = "wasm32")]
         {
@@ -1033,6 +1034,7 @@ impl App {
                 let local_decode = Self::do_decode_lookup(&lookup, &selector, &data).await;
                 let mut guard = result.lock().unwrap();
                 *guard = Some(DecodeResult::Single { selector, local_decode });
+                ctx.request_repaint();
             });
         }
 
@@ -1043,6 +1045,7 @@ impl App {
                 let local_decode = rt.block_on(Self::do_decode_lookup(&lookup, &selector, &data));
                 let mut guard = result.lock().unwrap();
                 *guard = Some(DecodeResult::Single { selector, local_decode });
+                ctx.request_repaint();
             });
         }
     }

--- a/crates/rusty-safe/src/decode/compare.rs
+++ b/crates/rusty-safe/src/decode/compare.rs
@@ -5,10 +5,7 @@ use alloy::primitives::U256;
 use super::types::*;
 
 /// Compare API decode against Local decode
-pub fn compare_decodes(
-    api: Option<&ApiDecode>,
-    local: Option<&LocalDecode>,
-) -> ComparisonResult {
+pub fn compare_decodes(api: Option<&ApiDecode>, local: Option<&LocalDecode>) -> ComparisonResult {
     match (api, local) {
         (None, None) => ComparisonResult::Failed("No decode available".into()),
         (Some(_), None) => ComparisonResult::OnlyApi,
@@ -170,20 +167,15 @@ mod tests {
         assert_eq!(normalize_int(large_hex), large_dec);
 
         // Test max uint256
-        let max_u256 = "115792089237316195423570985008687907853269984665640564039457584007913129639935";
+        let max_u256 =
+            "115792089237316195423570985008687907853269984665640564039457584007913129639935";
         assert_eq!(normalize_int(max_u256), max_u256);
     }
 
     #[test]
     fn test_values_match() {
-        assert!(values_match(
-            "0xAbCd",
-            "0xabcd",
-            "address"
-        ));
+        assert!(values_match("0xAbCd", "0xabcd", "address"));
         assert!(values_match("1000", "0x3e8", "uint256"));
         assert!(!values_match("1000", "2000", "uint256"));
     }
 }
-
-

--- a/crates/rusty-safe/src/decode/mod.rs
+++ b/crates/rusty-safe/src/decode/mod.rs
@@ -21,7 +21,7 @@ pub use parser::{
     decode_multisend_bytes, decode_with_signature, get_selector, parse_initial,
     unpack_multisend_transactions, MULTISEND_SELECTOR,
 };
-pub use sourcify::SignatureLookup;
+pub use sourcify::{SignatureInfo, SignatureLookup};
 pub use types::*;
 pub use ui::{render_decode_section, render_offline_decode_section, render_single_comparison};
 pub use verify::verify_multisend_batch;

--- a/crates/rusty-safe/src/decode/sourcify.rs
+++ b/crates/rusty-safe/src/decode/sourcify.rs
@@ -5,11 +5,11 @@
 //!
 //! Cache is persisted via eframe storage (works on both WASM and native).
 
-use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use eyre::{Result, WrapErr};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
 
 const SOURCIFY_API: &str = "https://api.4byte.sourcify.dev/signature-database/v1/lookup";
 
@@ -69,8 +69,14 @@ struct SignatureEntry {
     name: String,
     #[allow(dead_code)]
     filtered: bool,
-    #[allow(dead_code)]
     has_verified_contract: Option<bool>,
+}
+
+/// A signature with its verification status
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SignatureInfo {
+    pub signature: String,
+    pub verified: bool,
 }
 
 /// Cached 4byte signature lookup client with spurious connection detection
@@ -79,7 +85,7 @@ struct SignatureEntry {
 /// `MAX_FAILED_REQUESTS` consecutive failures (timeout, network error, 5xx).
 #[derive(Clone)]
 pub struct SignatureLookup {
-    cache: Arc<Mutex<HashMap<String, Vec<String>>>>,
+    cache: Arc<Mutex<HashMap<String, Vec<SignatureInfo>>>>,
     /// Whether the API connection appears to be down
     is_spurious: Arc<AtomicBool>,
     /// Count of consecutive failed requests
@@ -95,7 +101,7 @@ impl Default for SignatureLookup {
 /// Serializable cache format for storage
 #[derive(Serialize, Deserialize, Default)]
 struct StoredCache {
-    signatures: HashMap<String, Vec<String>>,
+    signatures: HashMap<String, Vec<SignatureInfo>>,
 }
 
 impl SignatureLookup {
@@ -106,41 +112,44 @@ impl SignatureLookup {
             failed_count: Arc::new(AtomicUsize::new(0)),
         }
     }
-    
+
     /// Load cache from eframe storage
     pub fn load(storage: Option<&dyn eframe::Storage>) -> Self {
         let cache = if let Some(storage) = storage {
-            storage.get_string(SIGNATURES_STORAGE_KEY)
+            storage
+                .get_string(SIGNATURES_STORAGE_KEY)
                 .and_then(|s| serde_json::from_str::<StoredCache>(&s).ok())
                 .map(|c| c.signatures)
                 .unwrap_or_default()
         } else {
             HashMap::new()
         };
-        
+
         debug_log!("Loaded {} cached signatures from storage", cache.len());
-        
+
         Self {
             cache: Arc::new(Mutex::new(cache)),
             is_spurious: Arc::new(AtomicBool::new(false)),
             failed_count: Arc::new(AtomicUsize::new(0)),
         }
     }
-    
+
     /// Save cache to eframe storage
     pub fn save(&self, storage: &mut dyn eframe::Storage) {
         let cache = lock_or_recover!(self.cache);
-        
+
         // Limit cache size to prevent unbounded growth
-        let signatures: HashMap<String, Vec<String>> = if cache.len() > MAX_CACHED_SELECTORS {
-            cache.iter()
+        let signatures: HashMap<String, Vec<SignatureInfo>> = if cache.len() > MAX_CACHED_SELECTORS
+        {
+            cache
+                .iter()
                 .take(MAX_CACHED_SELECTORS)
                 .map(|(k, v)| (k.clone(), v.clone()))
                 .collect()
         } else {
             cache.clone()
         };
-        
+
         let stored = StoredCache { signatures };
         if let Ok(json) = serde_json::to_string(&stored) {
             storage.set_string(SIGNATURES_STORAGE_KEY, json);
@@ -168,13 +177,18 @@ impl SignatureLookup {
     fn on_failure(&self, err: &reqwest::Error) {
         // Only count connectivity-type errors (timeout, or server errors)
         // Note: is_connect() isn't available in WASM, so we check timeout and server errors
-        let is_connectivity_error = err.is_timeout() 
+        let is_connectivity_error = err.is_timeout()
             || err.status().map_or(false, |s| s.is_server_error())
-            || err.is_request();  // Catch other request-level failures
-        
+            || err.is_request(); // Catch other request-level failures
+
         if is_connectivity_error {
             let count = self.failed_count.fetch_add(1, Ordering::SeqCst) + 1;
-            debug_log!("Request failed ({}/{}): {}", count, MAX_FAILED_REQUESTS, err);
+            debug_log!(
+                "Request failed ({}/{}): {}",
+                count,
+                MAX_FAILED_REQUESTS,
+                err
+            );
             if count >= MAX_FAILED_REQUESTS {
                 debug_log!("Marking API as spurious after {} failures", count);
                 self.is_spurious.store(true, Ordering::Relaxed);
@@ -183,7 +197,8 @@ impl SignatureLookup {
     }
 
     /// Lookup a single selector (checks cache first)
-    pub async fn lookup(&self, selector: &str) -> Result<Vec<String>> {
+    /// Returns signatures with verification status, sorted by verified first
+    pub async fn lookup(&self, selector: &str) -> Result<Vec<SignatureInfo>> {
         // Short-circuit if API is marked as down
         if self.is_spurious() {
             debug_log!("Skipping lookup - API marked as spurious");
@@ -217,7 +232,8 @@ impl SignatureLookup {
     }
 
     /// Batch lookup multiple selectors (deduplicates, uses cache)
-    pub async fn lookup_batch(&self, selectors: &[String]) -> HashMap<String, Vec<String>> {
+    /// Returns signatures with verification status for each selector
+    pub async fn lookup_batch(&self, selectors: &[String]) -> HashMap<String, Vec<SignatureInfo>> {
         let mut results = HashMap::new();
         let mut to_fetch = Vec::new();
 
@@ -239,7 +255,11 @@ impl SignatureLookup {
             return results;
         }
 
-        debug_log!("Batch fetching {} selectors: {:?}", to_fetch.len(), to_fetch);
+        debug_log!(
+            "Batch fetching {} selectors: {:?}",
+            to_fetch.len(),
+            to_fetch
+        );
 
         // Fetch all uncached in one request
         match self.fetch_batch(&to_fetch).await {
@@ -266,14 +286,17 @@ impl SignatureLookup {
     }
 
     /// Fetch signatures for a selector from Sourcify
-    async fn fetch_single(&self, selector: &str) -> Result<Vec<String>> {
+    async fn fetch_single(&self, selector: &str) -> Result<Vec<SignatureInfo>> {
         self.fetch_batch(&[selector.to_string()])
             .await
             .map(|mut map| map.remove(selector).unwrap_or_default())
     }
 
     /// Fetch signatures for multiple selectors in one request
-    async fn fetch_batch(&self, selectors: &[String]) -> Result<HashMap<String, Vec<String>>> {
+    async fn fetch_batch(
+        &self,
+        selectors: &[String],
+    ) -> Result<HashMap<String, Vec<SignatureInfo>>> {
         if selectors.is_empty() {
             return Ok(HashMap::new());
         }
@@ -286,7 +309,11 @@ impl SignatureLookup {
 
         // Build URL with comma-delimited selectors
         // e.g., ?function=0xa9059cbb,0x095ea7b3&filter=true
-        let selectors_csv: String = selectors.iter().map(|s| s.as_str()).collect::<Vec<_>>().join(",");
+        let selectors_csv: String = selectors
+            .iter()
+            .map(|s| s.as_str())
+            .collect::<Vec<_>>()
+            .join(",");
         let url = format!("{}?function={}&filter=true", SOURCIFY_API, selectors_csv);
         debug_log!("Fetching: {}", url);
 
@@ -323,19 +350,22 @@ impl SignatureLookup {
         // Success - reset failure count
         self.on_success();
 
-        // Convert to our format, prioritizing verified signatures
+        // Convert to our format, preserving verification status
+        // Sort: verified contracts first
         let mut results = HashMap::new();
         for (selector, entries) in api_response.result.function {
-            // Sort: verified contracts first
-            let mut sigs: Vec<(bool, String)> = entries
+            let mut sigs: Vec<SignatureInfo> = entries
                 .into_iter()
-                .map(|e| (e.has_verified_contract.unwrap_or(false), e.name))
+                .map(|e| SignatureInfo {
+                    signature: e.name,
+                    verified: e.has_verified_contract.unwrap_or(false),
+                })
                 .collect();
-            sigs.sort_by(|a, b| b.0.cmp(&a.0)); // verified first
+            // Sort: verified first
+            sigs.sort_by(|a, b| b.verified.cmp(&a.verified));
 
-            let sig_names: Vec<String> = sigs.into_iter().map(|(_, name)| name).collect();
-            debug_log!("Selector {}: {:?}", selector, sig_names);
-            results.insert(selector, sig_names);
+            debug_log!("Selector {}: {:?}", selector, sigs);
+            results.insert(selector, sigs);
         }
 
         Ok(results)
@@ -363,5 +393,3 @@ mod tests {
         assert_eq!(normalize_selector("0xa9059cbb"), "0xa9059cbb");
     }
 }
-
-

--- a/crates/rusty-safe/src/decode/types.rs
+++ b/crates/rusty-safe/src/decode/types.rs
@@ -42,7 +42,9 @@ pub struct MultiSendDecode {
 pub enum VerificationState {
     #[default]
     Pending,
-    InProgress { total: usize },
+    InProgress {
+        total: usize,
+    },
     Complete,
 }
 
@@ -85,9 +87,9 @@ impl MultiSendSummary {
                     ComparisonResult::MethodMismatch { .. }
                     | ComparisonResult::ParamMismatch(_) => self.mismatched += 1,
                     // OnlyApi/OnlyLocal = no independent verification possible
-                    ComparisonResult::OnlyApi 
-                    | ComparisonResult::OnlyLocal 
-                    | ComparisonResult::Pending 
+                    ComparisonResult::OnlyApi
+                    | ComparisonResult::OnlyLocal
+                    | ComparisonResult::Pending
                     | ComparisonResult::Failed(_) => self.pending += 1,
                 },
                 None => self.pending += 1,
@@ -121,6 +123,8 @@ pub struct LocalDecode {
     pub signature: String,
     pub method: String,
     pub params: Vec<LocalParam>,
+    /// Whether this signature comes from a verified contract on Sourcify
+    pub verified: bool,
 }
 
 /// Parameter from local decode (no names, just types)
@@ -236,7 +240,10 @@ impl OfflineDecodeStatus {
     }
 
     pub fn is_error(&self) -> bool {
-        matches!(self, OfflineDecodeStatus::Unknown(_) | OfflineDecodeStatus::Failed(_))
+        matches!(
+            self,
+            OfflineDecodeStatus::Unknown(_) | OfflineDecodeStatus::Failed(_)
+        )
     }
 }
 
@@ -277,5 +284,3 @@ impl Default for OfflineDecodeResult {
         Self::Empty
     }
 }
-
-

--- a/crates/rusty-safe/src/decode/verify.rs
+++ b/crates/rusty-safe/src/decode/verify.rs
@@ -5,39 +5,40 @@
 use std::collections::HashSet;
 
 use super::compare;
+use super::decode_log;
 use super::parser;
 use super::sourcify::SignatureLookup;
 use super::types::*;
-use super::decode_log;
 
 /// Bulk verify all transactions in a MultiSend batch
-/// 
+///
 /// 1. Collects all unique selectors from transactions
 /// 2. Batch fetches signatures from Sourcify (uses cache)
 /// 3. Decodes each transaction locally
 /// 4. Compares with API decode
 /// 5. Updates summary
-pub async fn verify_multisend_batch(
-    multi: &mut MultiSendDecode,
-    lookup: &SignatureLookup,
-) {
-    decode_log!("Starting bulk verification for {} transactions", multi.transactions.len());
-    
+pub async fn verify_multisend_batch(multi: &mut MultiSendDecode, lookup: &SignatureLookup) {
+    decode_log!(
+        "Starting bulk verification for {} transactions",
+        multi.transactions.len()
+    );
+
     // 1. Collect unique selectors from all transactions with calldata
-    let selectors: Vec<String> = multi.transactions
+    let selectors: Vec<String> = multi
+        .transactions
         .iter()
         .filter(|tx| tx.data.len() >= 10 && tx.data != "0x")
         .map(|tx| tx.data[..10].to_lowercase())
         .collect::<HashSet<_>>()
         .into_iter()
         .collect();
-    
+
     decode_log!("Found {} unique selectors to lookup", selectors.len());
-    
+
     // 2. Batch fetch from Sourcify (handles cache internally)
     let signatures = lookup.lookup_batch(&selectors).await;
     decode_log!("Fetched signatures for {} selectors", signatures.len());
-    
+
     // 3. Decode each transaction
     for tx in &mut multi.transactions {
         // Skip empty calldata
@@ -45,9 +46,9 @@ pub async fn verify_multisend_batch(
             decode_log!("TX #{}: skipping (no calldata)", tx.index);
             continue;
         }
-        
+
         let selector = tx.data[..10].to_lowercase();
-        
+
         // Get signatures for this selector
         let sigs = match signatures.get(&selector) {
             Some(s) if !s.is_empty() => s,
@@ -66,40 +67,59 @@ pub async fn verify_multisend_batch(
                 continue;
             }
         };
-        
-        decode_log!("TX #{}: trying {} signatures for {}", tx.index, sigs.len(), selector);
-        
+
+        decode_log!(
+            "TX #{}: trying {} signatures for {}",
+            tx.index,
+            sigs.len(),
+            selector
+        );
+
         // Try each signature until one decodes successfully
+        // Signatures are sorted with verified first, so we prefer verified decodes
         let mut local_decode = None;
-        for sig in sigs {
-            match parser::decode_with_signature(&tx.data, sig) {
+        for sig_info in sigs {
+            match parser::decode_with_signature(&tx.data, &sig_info.signature, sig_info.verified) {
                 Ok(decoded) => {
-                    decode_log!("TX #{}: decoded with {}", tx.index, sig);
+                    decode_log!(
+                        "TX #{}: decoded with {} (verified: {})",
+                        tx.index,
+                        sig_info.signature,
+                        sig_info.verified
+                    );
                     local_decode = Some(decoded);
                     break;
                 }
                 Err(e) => {
-                    decode_log!("TX #{}: failed to decode with {}: {}", tx.index, sig, e);
+                    decode_log!(
+                        "TX #{}: failed to decode with {}: {}",
+                        tx.index,
+                        sig_info.signature,
+                        e
+                    );
                 }
             }
         }
-        
+
         // 4. Compare with API decode
         let comparison = compare::compare_decodes(tx.api_decode.as_ref(), local_decode.as_ref());
         decode_log!("TX #{}: comparison result: {:?}", tx.index, comparison);
-        
+
         tx.decode = Some(SingleDecode {
             api: tx.api_decode.clone(),
             local: local_decode,
             comparison,
         });
     }
-    
+
     // 5. Update summary and mark complete
     multi.summary.update(&multi.transactions);
     multi.verification_state = VerificationState::Complete;
-    
-    decode_log!("Bulk verification complete: {} verified, {} mismatched, {} pending",
-        multi.summary.verified, multi.summary.mismatched, multi.summary.pending);
-}
 
+    decode_log!(
+        "Bulk verification complete: {} verified, {} mismatched, {} pending",
+        multi.summary.verified,
+        multi.summary.mismatched,
+        multi.summary.pending
+    );
+}

--- a/crates/rusty-safe/src/expected.rs
+++ b/crates/rusty-safe/src/expected.rs
@@ -72,8 +72,7 @@ pub fn render_section(ui: &mut egui::Ui, state: &mut ExpectedState) {
         .show(ui, |ui| {
             ui.add_space(5.0);
             ui.label(
-                egui::RichText::new("Enter expected values to verify against API response:")
-                    .weak(),
+                egui::RichText::new("Enter expected values to verify against API response:").weak(),
             );
             ui.add_space(8.0);
 
@@ -208,22 +207,20 @@ pub fn validate_against_api(api_tx: &SafeTransaction, state: &ExpectedState) -> 
     // Check value
     if !state.value.is_empty() {
         match parse_u256(&state.value) {
-            Ok(expected_value) => {
-                match U256::from_str_radix(&api_tx.value, 10) {
-                    Ok(api_value) => {
-                        if expected_value != api_value {
-                            mismatches.push(Mismatch {
-                                field: "value".to_string(),
-                                api_value: api_value.to_string(),
-                                user_value: expected_value.to_string(),
-                            });
-                        }
-                    }
-                    Err(_) => {
-                        parse_errors.push(format!("API returned invalid value: '{}'", api_tx.value));
+            Ok(expected_value) => match U256::from_str_radix(&api_tx.value, 10) {
+                Ok(api_value) => {
+                    if expected_value != api_value {
+                        mismatches.push(Mismatch {
+                            field: "value".to_string(),
+                            api_value: api_value.to_string(),
+                            user_value: expected_value.to_string(),
+                        });
                     }
                 }
-            }
+                Err(_) => {
+                    parse_errors.push(format!("API returned invalid value: '{}'", api_tx.value));
+                }
+            },
             Err(_) => {
                 parse_errors.push(format!("Invalid expected value: '{}'", state.value.trim()));
             }
@@ -296,5 +293,3 @@ fn op_to_string(op: u8) -> String {
         _ => format!("Unknown({})", op),
     }
 }
-
-

--- a/crates/rusty-safe/src/main.rs
+++ b/crates/rusty-safe/src/main.rs
@@ -1,5 +1,5 @@
 //! Rusty-Safe: A Rust-native Safe{Wallet} transaction verification GUI
-//! 
+//!
 //! Uses safe-utils from safe-hash-rs for all hash computation and chain data.
 
 mod api;

--- a/crates/rusty-safe/src/sidebar.rs
+++ b/crates/rusty-safe/src/sidebar.rs
@@ -1,9 +1,9 @@
 //! Sidebar component for Safe context (chain, address, version, info)
 
-use eframe::egui;
 use crate::hasher::SafeInfo;
 use crate::state::{SafeContext, SidebarState, SAFE_VERSIONS};
 use crate::ui;
+use eframe::egui;
 use safe_utils::Of;
 
 /// Sidebar action returned after rendering
@@ -23,7 +23,7 @@ pub fn render(
     chain_names: &[String],
 ) -> SidebarAction {
     let mut action = SidebarAction::None;
-    
+
     egui::SidePanel::left("safe_context_panel")
         .resizable(true)
         .default_width(280.0)
@@ -329,7 +329,7 @@ pub fn render(
                 ui.add_space(20.0);
             });
         });
-    
+
     // Show expand button when collapsed
     if sidebar.collapsed {
         egui::SidePanel::left("collapsed_sidebar")
@@ -342,7 +342,6 @@ pub fn render(
                 }
             });
     }
-    
+
     action
 }
-

--- a/crates/rusty-safe/src/state.rs
+++ b/crates/rusty-safe/src/state.rs
@@ -95,7 +95,10 @@ pub fn validate_address(value: &str) -> AddressValidation {
         Ok(addr) => {
             let checksummed = addr.to_checksum(None);
             // EIP-55: if it's all lowercase or all uppercase, it's valid (just not checksummed)
-            if value == checksummed || value[2..] == value[2..].to_lowercase() || value[2..] == value[2..].to_uppercase() {
+            if value == checksummed
+                || value[2..] == value[2..].to_lowercase()
+                || value[2..] == value[2..].to_uppercase()
+            {
                 AddressValidation::Valid
             } else {
                 AddressValidation::ChecksumMismatch
@@ -122,7 +125,8 @@ pub struct AddressBook {
 impl AddressBook {
     pub fn get_name(&self, address: &str, chain_id: u64) -> Option<String> {
         let addr_lower = address.to_lowercase();
-        self.entries.iter()
+        self.entries
+            .iter()
             .find(|e| e.address.to_lowercase() == addr_lower && e.chain_id == chain_id)
             .map(|e| e.name.clone())
     }
@@ -134,8 +138,10 @@ impl AddressBook {
         }
 
         let addr_lower = entry.address.to_lowercase();
-        if let Some(existing) = self.entries.iter_mut()
-            .find(|e| e.address.to_lowercase() == addr_lower && e.chain_id == entry.chain_id) 
+        if let Some(existing) = self
+            .entries
+            .iter_mut()
+            .find(|e| e.address.to_lowercase() == addr_lower && e.chain_id == entry.chain_id)
         {
             existing.name = entry.name;
         } else {
@@ -145,7 +151,8 @@ impl AddressBook {
 
     pub fn remove(&mut self, address: &str, chain_id: u64) {
         let addr_lower = address.to_lowercase();
-        self.entries.retain(|e| e.address.to_lowercase() != addr_lower || e.chain_id != chain_id);
+        self.entries
+            .retain(|e| e.address.to_lowercase() != addr_lower || e.chain_id != chain_id);
     }
 
     pub fn validate_entry(&self, entry: &AddressBookEntry) -> AddressValidation {
@@ -161,23 +168,30 @@ impl AddressBook {
             if line.is_empty() || line.starts_with("address,") {
                 continue;
             }
-            
+
             let parts: Vec<&str> = line.split(',').collect();
             if parts.len() < 3 {
                 skipped += 1;
                 continue;
             }
-            
+
             let address = parts[0].trim().to_string();
             let name = parts[1].trim().to_string();
-            let chain_id = parts[2].trim().parse::<u64>().map_err(|_| format!("Invalid chainId on line {}", i + 1))?;
-            
+            let chain_id = parts[2]
+                .trim()
+                .parse::<u64>()
+                .map_err(|_| format!("Invalid chainId on line {}", i + 1))?;
+
             if validate_address(&address) == AddressValidation::Invalid {
                 skipped += 1;
                 continue;
             }
 
-            self.add_or_update(AddressBookEntry { address, name, chain_id });
+            self.add_or_update(AddressBookEntry {
+                address,
+                name,
+                chain_id,
+            });
             count += 1;
         }
         Ok((count, skipped))
@@ -187,7 +201,10 @@ impl AddressBook {
     pub fn export_csv(&self) -> String {
         let mut csv = String::from("address,name,chainId\n");
         for entry in &self.entries {
-            csv.push_str(&format!("{},{},{}\n", entry.address, entry.name, entry.chain_id));
+            csv.push_str(&format!(
+                "{},{},{}\n",
+                entry.address, entry.name, entry.chain_id
+            ));
         }
         csv
     }
@@ -197,24 +214,27 @@ impl SafeContext {
     /// Load SafeContext from eframe storage
     pub fn load(storage: Option<&dyn eframe::Storage>) -> Self {
         let chains = get_all_supported_chain_names();
-        let default_chain = chains.iter()
+        let default_chain = chains
+            .iter()
             .find(|c| *c == "ethereum")
             .cloned()
             .unwrap_or_else(|| chains.first().cloned().unwrap_or_default());
-        
+
         let (safe_address, recent_addresses, address_book) = if let Some(storage) = storage {
             let addr = storage.get_string(SAFE_ADDRESS_KEY).unwrap_or_default();
-            let recent: Vec<String> = storage.get_string(RECENT_ADDRESSES_KEY)
+            let recent: Vec<String> = storage
+                .get_string(RECENT_ADDRESSES_KEY)
                 .and_then(|s| serde_json::from_str(&s).ok())
                 .unwrap_or_default();
-            let book: AddressBook = storage.get_string(ADDRESS_BOOK_KEY)
+            let book: AddressBook = storage
+                .get_string(ADDRESS_BOOK_KEY)
                 .and_then(|s| serde_json::from_str(&s).ok())
                 .unwrap_or_default();
             (addr, recent, book)
         } else {
             (String::new(), Vec::new(), AddressBook::default())
         };
-        
+
         Self {
             chain_name: default_chain,
             safe_address,
@@ -223,7 +243,7 @@ impl SafeContext {
             address_book,
         }
     }
-    
+
     /// Save SafeContext to eframe storage
     pub fn save(&self, storage: &mut dyn eframe::Storage) {
         storage.set_string(SAFE_ADDRESS_KEY, self.safe_address.clone());
@@ -234,7 +254,7 @@ impl SafeContext {
             storage.set_string(ADDRESS_BOOK_KEY, json);
         }
     }
-    
+
     /// Clear all stored data
     pub fn clear(&mut self) {
         self.safe_address.clear();
@@ -407,18 +427,30 @@ mod tests {
         let mut book = AddressBook::default();
         // One valid checksummed, one valid unchecksummed (lowercase), one invalid
         let csv = "address,name,chainId\n0x4F2083f5fBede34C2714aFfb3105539775f7FE64,endowment.ensdao.eth,1\n0xfe89cc7abb2c4183683ab71653c4cdc9b02d44b7,test,1\n0xinvalid,bad,1";
-        
+
         let (count, skipped) = book.import_csv(csv).unwrap();
         assert_eq!(count, 2);
         assert_eq!(skipped, 1);
         assert_eq!(book.entries.len(), 2);
-        
+
         // Both should be checksummed now
-        assert_eq!(book.entries[0].address, "0x4F2083f5fBede34C2714aFfb3105539775f7FE64");
-        assert_eq!(book.entries[1].address, "0xFe89cc7aBB2C4183683ab71653C4cdc9B02D44b7");
-        
-        assert_eq!(book.get_name("0x4F2083f5fBede34C2714aFfb3105539775f7FE64", 1), Some("endowment.ensdao.eth".to_string()));
-        assert_eq!(book.get_name("0xfe89cc7abb2c4183683ab71653c4cdc9b02d44b7", 1), Some("test".to_string()));
+        assert_eq!(
+            book.entries[0].address,
+            "0x4F2083f5fBede34C2714aFfb3105539775f7FE64"
+        );
+        assert_eq!(
+            book.entries[1].address,
+            "0xFe89cc7aBB2C4183683ab71653C4cdc9B02D44b7"
+        );
+
+        assert_eq!(
+            book.get_name("0x4F2083f5fBede34C2714aFfb3105539775f7FE64", 1),
+            Some("endowment.ensdao.eth".to_string())
+        );
+        assert_eq!(
+            book.get_name("0xfe89cc7abb2c4183683ab71653c4cdc9b02d44b7", 1),
+            Some("test".to_string())
+        );
     }
 
     #[test]
@@ -434,7 +466,7 @@ mod tests {
             name: "New".to_string(),
             chain_id: 1,
         });
-        
+
         assert_eq!(book.entries.len(), 1);
         assert_eq!(book.get_name("0x123", 1), Some("New".to_string()));
     }

--- a/crates/rusty-safe/src/state.rs
+++ b/crates/rusty-safe/src/state.rs
@@ -269,6 +269,8 @@ pub struct TxVerifyState {
     pub fetched_tx: Option<SafeTransaction>,
     pub hashes: Option<ComputedHashes>,
     pub warnings: SafeWarnings,
+    /// Set when warnings couldn't be computed due to parse errors
+    pub warnings_error: Option<String>,
     pub is_loading: bool,
     pub error: Option<String>,
 }
@@ -278,6 +280,7 @@ impl TxVerifyState {
         self.fetched_tx = None;
         self.hashes = None;
         self.warnings = SafeWarnings::new();
+        self.warnings_error = None;
         self.expected.clear_result();
         self.decode = None;
         self.error = None;
@@ -349,12 +352,14 @@ pub struct OfflineState {
     pub gas_price: String,
     pub gas_token: String,
     pub refund_receiver: String,
-    
+
     // Results
     pub decode_result: Option<OfflineDecodeResult>,
     pub hashes: Option<ComputedHashes>,
     pub warnings: SafeWarnings,
-    
+    /// Set when warnings couldn't be computed due to parse errors
+    pub warnings_error: Option<String>,
+
     // State
     pub is_loading: bool,
     pub error: Option<String>,
@@ -376,6 +381,7 @@ impl Default for OfflineState {
             decode_result: None,
             hashes: None,
             warnings: SafeWarnings::new(),
+            warnings_error: None,
             is_loading: false,
             error: None,
         }
@@ -387,6 +393,7 @@ impl OfflineState {
         self.decode_result = None;
         self.hashes = None;
         self.warnings = SafeWarnings::new();
+        self.warnings_error = None;
         self.error = None;
     }
 }

--- a/crates/rusty-safe/src/ui.rs
+++ b/crates/rusty-safe/src/ui.rs
@@ -51,13 +51,18 @@ pub fn open_url_new_tab(url: &str) {
     let _ = open::that(url);
 }
 
-pub use crate::state::{AddressValidation, validate_address};
+pub use crate::state::{validate_address, AddressValidation};
 
 /// Render an address as a clickable hyperlink that opens in block explorer
-pub fn address_link(ui: &mut egui::Ui, chain_name: &str, address: &str, name: Option<String>) -> egui::Response {
+pub fn address_link(
+    ui: &mut egui::Ui,
+    chain_name: &str,
+    address: &str,
+    name: Option<String>,
+) -> egui::Response {
     let validation = validate_address(address);
     let explorer_url = get_explorer_address_url(chain_name, address);
-    
+
     let text_color = if validation == AddressValidation::ChecksumMismatch {
         egui::Color32::from_rgb(220, 180, 50) // Yellow for checksum warning
     } else {
@@ -71,7 +76,12 @@ pub fn address_link(ui: &mut egui::Ui, chain_name: &str, address: &str, name: Op
             address.to_string()
         };
 
-        let response = ui.link(egui::RichText::new(label_text).monospace().color(text_color))
+        let response = ui
+            .link(
+                egui::RichText::new(label_text)
+                    .monospace()
+                    .color(text_color),
+            )
             .on_hover_text(if validation == AddressValidation::ChecksumMismatch {
                 "⚠️ Checksum mismatch! Click to open in block explorer"
             } else {
@@ -86,9 +96,10 @@ pub fn address_link(ui: &mut egui::Ui, chain_name: &str, address: &str, name: Op
             ui.label(egui::RichText::new("⚠️").color(egui::Color32::from_rgb(220, 180, 50)))
                 .on_hover_text("Address has an invalid EIP-55 checksum");
         }
-        
+
         response
-    }).inner
+    })
+    .inner
 }
 
 /// Styled heading with accent color
@@ -111,7 +122,11 @@ pub fn labeled_field_with_copy(ui: &mut egui::Ui, label: &str, value: &str) -> b
     ui.horizontal(|ui| {
         ui.label(egui::RichText::new(format!("{}:", label)).strong());
         ui.label(egui::RichText::new(value).monospace());
-        if ui.small_button("📋").on_hover_text("Copy to clipboard").clicked() {
+        if ui
+            .small_button("📋")
+            .on_hover_text("Copy to clipboard")
+            .clicked()
+        {
             copied = true;
         }
     });
@@ -135,7 +150,6 @@ pub fn copy_to_clipboard(text: &str) {
     }
 }
 
-
 /// Create a styled text edit for address input
 pub fn address_input(ui: &mut egui::Ui, value: &mut String) -> egui::Response {
     ui.add(
@@ -157,21 +171,28 @@ pub fn number_input(ui: &mut egui::Ui, value: &mut String, hint: &str) -> egui::
 }
 
 /// Create a styled multiline text edit with fixed height and internal scrolling
-pub fn multiline_input(ui: &mut egui::Ui, value: &mut String, hint: &str, rows: usize) -> egui::Response {
+pub fn multiline_input(
+    ui: &mut egui::Ui,
+    value: &mut String,
+    hint: &str,
+    rows: usize,
+) -> egui::Response {
     // Calculate height based on row count (approximate line height)
     let row_height = ui.text_style_height(&egui::TextStyle::Monospace);
     let height = row_height * rows as f32 + ui.spacing().item_spacing.y * 5.0;
-    
+
     let mut response = None;
     egui::ScrollArea::vertical()
         .max_height(height)
         .show(ui, |ui| {
-            response = Some(ui.add(
-                egui::TextEdit::multiline(value)
-                    .hint_text(hint)
-                    .desired_width(f32::INFINITY)
-                    .font(egui::TextStyle::Monospace),
-            ));
+            response = Some(
+                ui.add(
+                    egui::TextEdit::multiline(value)
+                        .hint_text(hint)
+                        .desired_width(f32::INFINITY)
+                        .font(egui::TextStyle::Monospace),
+                ),
+            );
         });
     response.unwrap()
 }
@@ -212,7 +233,11 @@ pub fn warning_message(ui: &mut egui::Ui, message: &str, color: egui::Color32) {
 pub fn copyable_hash(ui: &mut egui::Ui, hash: &str) {
     ui.horizontal(|ui| {
         ui.label(egui::RichText::new(hash).monospace());
-        if ui.small_button("📋").on_hover_text("Copy to clipboard").clicked() {
+        if ui
+            .small_button("📋")
+            .on_hover_text("Copy to clipboard")
+            .clicked()
+        {
             copy_to_clipboard(hash);
         }
     });
@@ -229,9 +254,10 @@ pub fn copyable_hash(ui: &mut egui::Ui, hash: &str) {
 pub fn hash_to_binary_literal(hash: &str) -> String {
     let hex = hash.strip_prefix("0x").unwrap_or(hash);
     let mut result = String::new();
-    
+
     // Convert hex pairs to bytes
-    let bytes: Vec<u8> = hex.as_bytes()
+    let bytes: Vec<u8> = hex
+        .as_bytes()
         .chunks(2)
         .filter_map(|chunk| {
             if chunk.len() == 2 {
@@ -242,7 +268,7 @@ pub fn hash_to_binary_literal(hash: &str) -> String {
             }
         })
         .collect();
-    
+
     // Format each byte: printable ASCII as-is, others as \xNN
     for byte in bytes {
         if (32..=126).contains(&byte) {
@@ -253,7 +279,7 @@ pub fn hash_to_binary_literal(hash: &str) -> String {
             result.push_str(&format!("\\x{:02x}", byte));
         }
     }
-    
+
     result
 }
 
@@ -286,11 +312,11 @@ pub fn format_uint_with_decimals(value: &str, decimals: u8) -> String {
     if decimals == 0 {
         return add_thousand_separators(value);
     }
-    
+
     let trimmed = value.trim();
     let len = trimmed.len();
     let dec = decimals as usize;
-    
+
     if len <= dec {
         // Value is smaller than the decimal places
         let zeros = "0".repeat(dec - len);
@@ -299,12 +325,12 @@ pub fn format_uint_with_decimals(value: &str, decimals: u8) -> String {
         // Split into integer and decimal parts
         let int_part = &trimmed[..len - dec];
         let dec_part = &trimmed[len - dec..];
-        
+
         // Trim trailing zeros from decimal part
         let dec_trimmed = dec_part.trim_end_matches('0');
-        
+
         let int_formatted = add_thousand_separators(int_part);
-        
+
         if dec_trimmed.is_empty() {
             format!("{}.0", int_formatted)
         } else {
@@ -317,84 +343,88 @@ pub fn format_uint_with_decimals(value: &str, decimals: u8) -> String {
 fn add_thousand_separators(s: &str) -> String {
     let chars: Vec<char> = s.chars().collect();
     let mut result = String::new();
-    
+
     for (i, c) in chars.iter().enumerate() {
         if i > 0 && (chars.len() - i) % 3 == 0 {
             result.push(',');
         }
         result.push(*c);
     }
-    
+
     result
 }
 
 /// Render a clickable uint value with decimal popup
 pub fn render_uint_with_popup(ui: &mut egui::Ui, value: &str, id_salt: &str) {
     let popup_id = ui.make_persistent_id(format!("uint_popup_{}", id_salt));
-    
+
     // Get/create state for this popup
     let mut state = ui.memory(|m| {
-        m.data.get_temp::<UintPopupState>(popup_id).unwrap_or(UintPopupState { decimals: 18 })
+        m.data
+            .get_temp::<UintPopupState>(popup_id)
+            .unwrap_or(UintPopupState { decimals: 18 })
     });
-    
+
     // Clickable value label
-    let response = ui.add(
-        egui::Button::new(egui::RichText::new(value).monospace())
-            .frame(false)
-    );
-    
+    let response = ui.add(egui::Button::new(egui::RichText::new(value).monospace()).frame(false));
+
     if response.clicked() {
         ui.memory_mut(|m| m.toggle_popup(popup_id));
     }
-    
+
     // Show popup below the value
-    egui::popup_below_widget(ui, popup_id, &response, egui::PopupCloseBehavior::CloseOnClickOutside, |ui| {
-        ui.set_min_width(200.0);
-        
-        // Formatted value with copy button
-        let formatted = format_uint_with_decimals(value, state.decimals);
-        ui.horizontal(|ui| {
-            ui.label(egui::RichText::new(&formatted).monospace().strong());
-            if ui.small_button("📋").on_hover_text("Copy").clicked() {
-                copy_to_clipboard(&formatted);
-            }
-        });
-        
-        ui.separator();
-        
-        // Decimals input field
-        ui.horizontal(|ui| {
-            ui.label("Decimals:");
-            let mut dec_str = state.decimals.to_string();
-            let response = ui.add(
-                egui::TextEdit::singleline(&mut dec_str)
-                    .desired_width(40.0)
-                    .font(egui::TextStyle::Monospace)
-            );
-            if response.changed() {
-                if let Ok(d) = dec_str.parse::<u8>() {
-                    if d <= 77 {
-                        state.decimals = d;
+    egui::popup_below_widget(
+        ui,
+        popup_id,
+        &response,
+        egui::PopupCloseBehavior::CloseOnClickOutside,
+        |ui| {
+            ui.set_min_width(200.0);
+
+            // Formatted value with copy button
+            let formatted = format_uint_with_decimals(value, state.decimals);
+            ui.horizontal(|ui| {
+                ui.label(egui::RichText::new(&formatted).monospace().strong());
+                if ui.small_button("📋").on_hover_text("Copy").clicked() {
+                    copy_to_clipboard(&formatted);
+                }
+            });
+
+            ui.separator();
+
+            // Decimals input field
+            ui.horizontal(|ui| {
+                ui.label("Decimals:");
+                let mut dec_str = state.decimals.to_string();
+                let response = ui.add(
+                    egui::TextEdit::singleline(&mut dec_str)
+                        .desired_width(40.0)
+                        .font(egui::TextStyle::Monospace),
+                );
+                if response.changed() {
+                    if let Ok(d) = dec_str.parse::<u8>() {
+                        if d <= 77 {
+                            state.decimals = d;
+                        }
                     }
                 }
-            }
-        });
-        
-        // Preset buttons
-        ui.horizontal(|ui| {
-            for (label, dec) in [("18", 18), ("9", 9), ("8", 8), ("6", 6), ("0", 0)] {
-                let selected = state.decimals == dec;
-                if ui.selectable_label(selected, label).clicked() {
-                    state.decimals = dec;
+            });
+
+            // Preset buttons
+            ui.horizontal(|ui| {
+                for (label, dec) in [("18", 18), ("9", 9), ("8", 8), ("6", 6), ("0", 0)] {
+                    let selected = state.decimals == dec;
+                    if ui.selectable_label(selected, label).clicked() {
+                        state.decimals = dec;
+                    }
                 }
-            }
-        });
-        
-        // Hint text
-        ui.label(egui::RichText::new("18=wei  9=gwei  6=USDC").weak().small());
-    });
-    
+            });
+
+            // Hint text
+            ui.label(egui::RichText::new("18=wei  9=gwei  6=USDC").weak().small());
+        },
+    );
+
     // Store state
     ui.memory_mut(|m| m.data.insert_temp(popup_id, state));
 }
-


### PR DESCRIPTION
## Summary

This PR addresses multiple security and reliability issues identified during a comprehensive audit of the codebase. The changes focus on production hardening for this wallet-adjacent application.

### Bug Fixes

#### Critical/High Severity
- **Message hash hex flag ignored** (`8186a2b`) - `compute_message_hash` now respects the `is_hex` flag, parsing hex bytes correctly instead of always treating input as UTF-8
- **Missing UI repaint after decode lookup** (`2029448`) - Added `ctx.request_repaint()` to `trigger_decode_lookup` so the UI updates when async decode results are ready

#### Medium Severity  
- **Integer comparison truncates large values** (`88edf2a`) - Changed `normalize_int` to use `U256` instead of `u128`, fixing false mismatch reports for values > 2^128 (common in token transfers)
- **Expected value validation silently skips invalid inputs** (`d12e26a`) - Added `ValidationResult::ParseErrors` variant; validation now reports all parse errors explicitly instead of returning false "Match"
- **Warning computation coerces parse failures to zero** (`d12e26a`) - `get_warnings_for_tx` and `get_warnings_from_api_tx` now return `Result<SafeWarnings>`, propagating parse errors instead of suppressing them
- **Warning computation failures not surfaced to users** (`9ad2930`) - UI now displays warning section when `warnings_error` is set, showing "Warning computation failed" message

#### Low Severity
- **Mutex unwraps can panic** (`6d97a84`) - Added `lock_or_recover!` macro that handles poisoned mutexes gracefully, recovering inner data instead of panicking. Replaced 20 occurrences across `app.rs` and `sourcify.rs`

### New Features

#### Signature Verification Status (`91b11bd`)
- **Problem**: 4byte signatures from Sourcify were treated equally regardless of whether they came from a verified contract
- **Solution**: Now track `hasVerifiedContract` from the Sourcify API and display verification status in UI
- **UI Changes**:
  - Verified signatures: Display normally
  - Unverified signatures: Show **`[unverified]`** in red next to method name
- **Locations updated**: Online decode, offline decode, MultiSend transaction headers

### Infrastructure
- **Rust coding guidelines** (`c6b6e27`) - Added Rust-specific guidelines to CLAUDE.md
- **CI workflow cleanup** (`36f69af`, `7563fd3`) - Disabled deploy-local-no-attestation by default, formatting fixes
- **Audit documentation** - Added `PRODUCTION_HARDENING.md` and `TEST_COVERAGE_REQUIREMENTS.md`

## Technical Details

### `lock_or_recover!` Macro
```rust
macro_rules! lock_or_recover {
    ($mutex:expr) => {
        match $mutex.lock() {
            Ok(guard) => guard,
            Err(poisoned) => {
                debug_log!("Warning: Mutex was poisoned, recovering");
                poisoned.into_inner()
            }
        }
    };
}
```

### SignatureInfo Type
```rust
#[derive(Debug, Clone, Serialize, Deserialize)]
pub struct SignatureInfo {
    pub signature: String,
    pub verified: bool,  // true if from verified contract on Sourcify
}
```

### LocalDecode with Verification
```rust
pub struct LocalDecode {
    pub signature: String,
    pub method: String,
    pub params: Vec<LocalParam>,
    pub verified: bool,  // NEW: tracks verification status
}
```

## Test Plan

- [x] `cargo test` - All 11 tests pass
- [x] `cargo check` - No compilation errors
- [x] `cargo clippy` - Only unused import warnings (pre-existing)
- [ ] Manual testing of message hash with hex mode enabled
- [ ] Manual testing of expected value validation with invalid inputs
- [ ] Manual testing of large uint256 value comparison
- [ ] Verify warning errors display in UI when API returns malformed data
- [ ] Verify [unverified] label appears for unverified signatures

## Related Documentation

See `PRODUCTION_HARDENING.md` for full audit findings and remaining issues.
See `TEST_COVERAGE_REQUIREMENTS.md` for test coverage gaps and requirements.

## Remaining Issues (not in this PR)

| Issue | Severity | Description |
|-------|----------|-------------|
| #4 | MEDIUM | Signature cache has no integrity checking |
| #7 | MEDIUM | Unpinned git dependencies |
| #9 | LOW | MultiSend header shows unverified API data |
| #11 | LOW | Non-checksummed addresses accepted without warning |
| #12 | LOW | Empty nested calldata shows "Pending" |

**Note**: Issue #1 (4byte signature trust model) has been partially addressed by showing `[unverified]` for unverified signatures. Full remediation would require additional UI changes to show all candidate signatures when multiple exist.