### PR TITLE
feat: Multi-transaction support and UX improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4790,6 +4790,7 @@ dependencies = [
  "tracing-wasm",
  "wasm-bindgen-futures",
  "web-sys",
+ "web-time",
 ]
 
 [[package]]

--- a/crates/rusty-safe/Cargo.toml
+++ b/crates/rusty-safe/Cargo.toml
@@ -34,6 +34,7 @@ serde_json.workspace = true
 thiserror.workspace = true
 eyre.workspace = true
 semver.workspace = true
+web-time = "1.1"
 
 # Logging
 tracing.workspace = true

--- a/crates/rusty-safe/src/app.rs
+++ b/crates/rusty-safe/src/app.rs
@@ -516,8 +516,8 @@ impl App {
                     ui.end_row();
 
                     if let Some(execution_date) = &tx.execution_date {
-                        ui.label("Execution Date:");
-                        ui.label(execution_date);
+                        ui.label("Executed:");
+                        ui.label(Self::format_datetime(execution_date));
                         ui.label(""); // Empty for alignment
                         ui.end_row();
                     }

--- a/crates/rusty-safe/src/app.rs
+++ b/crates/rusty-safe/src/app.rs
@@ -343,10 +343,11 @@ impl App {
                     if pending_count > 0 {
                         if ui
                             .small_button(format!("⏳ Pending: {}", pending_count))
-                            .on_hover_text("Click to set nonce to pending count")
+                            .on_hover_text("Click to set nonce to latest pending transaction")
                             .clicked()
                         {
-                            self.tx_state.nonce = pending_count.to_string();
+                            // Nonce is 0-indexed, so latest pending is at pending_count - 1
+                            self.tx_state.nonce = (pending_count - 1).to_string();
                         }
                     }
                 }

--- a/crates/rusty-safe/src/app.rs
+++ b/crates/rusty-safe/src/app.rs
@@ -316,7 +316,7 @@ impl App {
                 let latest_nonce = if info.nonce > 0 { info.nonce - 1 } else { 0 };
                 if ui
                     .small_button(format!("⟳ Latest: {}", latest_nonce))
-                    .on_hover_text("Click to use most recent queued nonce")
+                    .on_hover_text(format!("Set nonce to {}", latest_nonce))
                     .clicked()
                 {
                     self.tx_state.nonce = latest_nonce.to_string();
@@ -329,7 +329,7 @@ impl App {
                         let pending_nonce = pending_count - 1;
                         if ui
                             .small_button(format!("⏳ Pending: {}", pending_nonce))
-                            .on_hover_text(format!("{} pending transaction(s)", pending_count))
+                            .on_hover_text(format!("Set nonce to {}", pending_nonce))
                             .clicked()
                         {
                             self.tx_state.nonce = pending_nonce.to_string();

--- a/crates/rusty-safe/src/app.rs
+++ b/crates/rusty-safe/src/app.rs
@@ -1634,8 +1634,8 @@ impl App {
 
                     self.safe_info = Some(info);
 
-                    // Schedule auto-fetch after 1 second delay to avoid API rate limits
-                    self.auto_fetch_after = Some(Instant::now() + Duration::from_millis(300));
+                    // Schedule auto-fetch after brief delay for UI to update
+                    self.auto_fetch_after = Some(Instant::now() + Duration::from_millis(50));
                 }
                 SafeInfoResult::Error(e) => {
                     debug_log!("Failed to fetch Safe info: {}", e);

--- a/crates/rusty-safe/src/app.rs
+++ b/crates/rusty-safe/src/app.rs
@@ -11,9 +11,7 @@ use safe_utils::{
 use std::sync::{Arc, Mutex};
 
 use crate::api::SafeTransaction;
-use crate::decode::{
-    self, get_selector, ComparisonResult, SignatureLookup, SingleDecode, TransactionKind,
-};
+use crate::decode::{self, ComparisonResult, SignatureLookup, TransactionKind};
 
 /// Log to console (works in both WASM and native)
 macro_rules! debug_log {
@@ -44,7 +42,7 @@ macro_rules! lock_or_recover {
 }
 use crate::expected;
 use crate::hasher::{
-    compute_hashes_from_api_tx, fetch_transaction, get_warnings_for_tx, get_warnings_from_api_tx,
+    compute_hashes_from_api_tx, fetch_transactions, get_warnings_for_tx, get_warnings_from_api_tx,
 };
 use crate::sidebar;
 use crate::state::{
@@ -56,7 +54,7 @@ use crate::ui;
 /// Result from async fetch operation
 #[derive(Clone)]
 pub enum FetchResult {
-    Success(SafeTransaction),
+    Success(Vec<SafeTransaction>),
     Error(String),
 }
 
@@ -278,9 +276,15 @@ impl App {
     fn render_verify_safe_api_tab(&mut self, ui: &mut egui::Ui, ctx: &egui::Context) {
         ui::styled_heading(ui, "Verify Safe API");
         ui.label("Verify Safe transaction hashes before signing.");
-        ui.add_space(15.0);
 
-        // Nonce input
+        ui.add_space(12.0);
+        ui.separator();
+        ui.add_space(8.0);
+
+        // Select Transaction section
+        ui.label(egui::RichText::new("Select Transaction").strong().size(13.0));
+        ui.add_space(6.0);
+
         ui.horizontal(|ui| {
             ui.label("Nonce:");
 
@@ -355,14 +359,113 @@ impl App {
             ui::error_message(ui, error);
         }
 
+        if self.tx_state.fetched_txs.len() > 1 {
+            ui.add_space(10.0);
+            ui::section_header(ui, "Select Transaction");
+            ui::warning_banner(
+                ui,
+                "Multiple transactions found for this nonce. Safe API keeps all proposals with the same nonce (replacements/cancellations). Select one to verify.",
+            );
+
+            let mut selected_index = self.tx_state.selected_tx_index.unwrap_or(0);
+            if selected_index >= self.tx_state.fetched_txs.len() {
+                selected_index = 0;
+            }
+
+            let show_submission_date = true;
+            let mut selection_changed = false;
+            ui.add_space(6.0);
+            egui::ScrollArea::vertical()
+                .max_height(120.0)
+                .show(ui, |ui| {
+                    for (idx, tx) in self.tx_state.fetched_txs.iter().enumerate() {
+                        let label = self.format_tx_label(idx, tx, false, show_submission_date);
+                        let selected = selected_index == idx;
+                        let indicator = if selected { "●" } else { "○" };
+
+                        // Determine colors based on selection state
+                        let (bg_color, text_color) = if selected {
+                            (
+                                egui::Color32::from_rgb(0, 150, 120),
+                                egui::Color32::WHITE,
+                            )
+                        } else {
+                            (
+                                egui::Color32::from_rgb(45, 45, 45),
+                                egui::Color32::from_rgb(200, 200, 200),
+                            )
+                        };
+
+                        let full_label = format!("{} {}", indicator, label);
+                        let response = egui::Frame::none()
+                            .fill(bg_color)
+                            .rounding(4.0)
+                            .inner_margin(egui::Margin::symmetric(10.0, 6.0))
+                            .show(ui, |ui| {
+                                ui.set_min_width(ui.available_width());
+                                ui.label(
+                                    egui::RichText::new(&full_label)
+                                        .size(13.0)
+                                        .color(text_color),
+                                );
+                            })
+                            .response
+                            .interact(egui::Sense::click())
+                            .on_hover_cursor(egui::CursorIcon::PointingHand);
+
+                        if response.clicked() {
+                            selected_index = idx;
+                            selection_changed = true;
+                        }
+                        ui.add_space(4.0);
+                    }
+                });
+
+            if selection_changed {
+                self.tx_state.selected_tx_index = Some(selected_index);
+                if let Some(tx) = self.tx_state.fetched_txs.get(selected_index).cloned() {
+                    self.apply_fetched_tx(ctx, tx);
+                }
+            }
+        }
+
         if let Some(tx) = &self.tx_state.fetched_tx {
             ui.add_space(15.0);
             ui::section_header(ui, "Transaction Details");
+
+            let action_label = self.tx_action_label(tx);
+            let status_label = Self::tx_status_label(tx);
 
             egui::Grid::new("tx_details")
                 .num_columns(3)
                 .spacing([10.0, 6.0])
                 .show(ui, |ui| {
+                    ui.label("Safe Tx Hash:");
+                    ui.label(
+                        egui::RichText::new(&tx.safe_tx_hash)
+                            .monospace()
+                            .size(11.0),
+                    );
+                    if ui.small_button("📋").on_hover_text("Copy").clicked() {
+                        ui::copy_to_clipboard(&tx.safe_tx_hash);
+                    }
+                    ui.end_row();
+
+                    ui.label("Status:");
+                    ui.label(status_label);
+                    ui.label(""); // Empty for alignment
+                    ui.end_row();
+
+                    ui.label("Action:");
+                    ui.label(&action_label);
+                    ui.label(""); // Empty for alignment
+                    ui.end_row();
+
+                    ui.label("Submitted:");
+                    ui.label(&tx.submission_date);
+                    ui.label(""); // Empty for alignment
+                    ui.end_row();
+
                     ui.label("To:");
                     let to_str = format!("{}", tx.to);
                     let chain_id =
@@ -375,7 +478,7 @@ impl App {
                     ui.end_row();
 
                     ui.label("Value:");
-                    ui.label(format!("{} wei", tx.value));
+                    ui.label(ui::format_wei_value(&tx.value));
                     ui.label(""); // Empty for alignment
                     ui.end_row();
 
@@ -396,6 +499,29 @@ impl App {
                     ));
                     ui.label(""); // Empty for alignment
                     ui.end_row();
+
+                    if let Some(execution_date) = &tx.execution_date {
+                        ui.label("Execution Date:");
+                        ui.label(execution_date);
+                        ui.label(""); // Empty for alignment
+                        ui.end_row();
+                    }
+
+                    if let Some(tx_hash) = &tx.transaction_hash {
+                        ui.label("Transaction Hash:");
+                        ui.label(egui::RichText::new(tx_hash).monospace().size(11.0));
+                        if ui.small_button("📋").on_hover_text("Copy").clicked() {
+                            ui::copy_to_clipboard(tx_hash);
+                        }
+                        ui.end_row();
+                    }
+
+                    if !tx.origin.is_empty() {
+                        ui.label("Origin:");
+                        ui.label(&tx.origin);
+                        ui.label(""); // Empty for alignment
+                        ui.end_row();
+                    }
                 });
 
             // Data field - full width outside grid
@@ -567,6 +693,126 @@ impl App {
                     ui::error_banner(ui, "Computed hash does NOT match API data!");
                 }
             }
+        }
+    }
+
+    fn format_tx_label(
+        &self,
+        index: usize,
+        tx: &SafeTransaction,
+        compact: bool,
+        show_submission_date: bool,
+    ) -> String {
+        let status = Self::tx_status_label(tx);
+        let action = self.tx_action_label(tx);
+        let hash = Self::shorten_middle(&tx.safe_tx_hash, 8, 6);
+        if compact {
+            let submitted = if show_submission_date {
+                format!(" | {}", Self::shorten_datetime(&tx.submission_date))
+            } else {
+                String::new()
+            };
+            return format!(
+                "Tx {}: {} | {}{} | {}",
+                index + 1,
+                status,
+                action,
+                submitted,
+                hash
+            );
+        }
+
+        let to = Self::shorten_middle(&format!("{}", tx.to), 6, 4);
+        let submitted = Self::shorten_datetime(&tx.submission_date);
+        format!(
+            "Tx {}: {} | {} | to {} | submitted {} | {}",
+            index + 1,
+            status,
+            action,
+            to,
+            submitted,
+            hash
+        )
+    }
+
+    fn tx_action_label(&self, tx: &SafeTransaction) -> String {
+        if let Some(decoded) = &tx.data_decoded {
+            if !decoded.method.is_empty() {
+                return decoded.method.clone();
+            }
+        }
+
+        let data_empty = Self::is_empty_data(&tx.data);
+        let value_zero = Self::is_zero_value(&tx.value);
+        let self_call = self.is_self_call(tx);
+
+        if data_empty && value_zero && self_call && tx.operation == 0 {
+            return "cancel (self-call)".to_string();
+        }
+
+        if data_empty && !value_zero {
+            return "eth transfer".to_string();
+        }
+
+        if data_empty {
+            return "empty calldata".to_string();
+        }
+
+        "unknown call".to_string()
+    }
+
+    fn is_self_call(&self, tx: &SafeTransaction) -> bool {
+        let safe_address = self.safe_context.safe_address.trim();
+        if safe_address.is_empty() {
+            return false;
+        }
+        match safe_address.parse::<alloy::primitives::Address>() {
+            Ok(addr) => addr == tx.to,
+            Err(_) => false,
+        }
+    }
+
+    fn is_empty_data(data: &str) -> bool {
+        let trimmed = data.trim();
+        trimmed.is_empty() || trimmed == "0x" || trimmed == "0X"
+    }
+
+    fn is_zero_value(value: &str) -> bool {
+        let trimmed = value.trim();
+        trimmed.is_empty() || trimmed == "0" || trimmed == "0x0" || trimmed == "0X0"
+    }
+
+    fn tx_status_label(tx: &SafeTransaction) -> &'static str {
+        if tx.is_executed {
+            match tx.is_successful {
+                Some(true) => "executed (success)",
+                Some(false) => "executed (failed)",
+                None => "executed",
+            }
+        } else {
+            "pending"
+        }
+    }
+
+    fn shorten_middle(value: &str, head: usize, tail: usize) -> String {
+        let trimmed = value.trim();
+        if trimmed.len() <= head + tail + 3 {
+            trimmed.to_string()
+        } else {
+            format!(
+                "{}...{}",
+                &trimmed[..head],
+                &trimmed[trimmed.len() - tail..]
+            )
+        }
+    }
+
+    fn shorten_datetime(value: &str) -> String {
+        let trimmed = value.trim();
+        if trimmed.len() > 19 {
+            trimmed[..19].to_string()
+        } else {
+            trimmed.to_string()
         }
     }
 
@@ -926,6 +1172,11 @@ impl App {
         self.tx_state.warnings = SafeWarnings::new();
         self.tx_state.hashes = None;
         self.tx_state.fetched_tx = None;
+        self.tx_state.fetched_txs.clear();
+        self.tx_state.selected_tx_index = None;
+        self.tx_state.decode = None;
+        self.tx_state.warnings_error = None;
+        self.tx_state.show_full_data = false;
 
         let chain_name = self.safe_context.chain_name.clone();
         let safe_address = self.safe_context.safe_address.clone();
@@ -945,10 +1196,10 @@ impl App {
         #[cfg(target_arch = "wasm32")]
         {
             wasm_bindgen_futures::spawn_local(async move {
-                let fetch_result = fetch_transaction(&chain_name, &safe_address, nonce).await;
+                let fetch_result = fetch_transactions(&chain_name, &safe_address, nonce).await;
                 let mut result_guard = lock_or_recover!(result);
                 *result_guard = Some(match fetch_result {
-                    Ok(tx) => FetchResult::Success(tx),
+                    Ok(txs) => FetchResult::Success(txs),
                     Err(e) => FetchResult::Error(format!("{:#}", e)),
                 });
                 ctx.request_repaint();
@@ -960,10 +1211,10 @@ impl App {
             std::thread::spawn(move || {
                 let rt = tokio::runtime::Runtime::new().unwrap();
                 let fetch_result =
-                    rt.block_on(fetch_transaction(&chain_name, &safe_address, nonce));
+                    rt.block_on(fetch_transactions(&chain_name, &safe_address, nonce));
                 let mut result_guard = lock_or_recover!(result);
                 *result_guard = Some(match fetch_result {
-                    Ok(tx) => FetchResult::Success(tx),
+                    Ok(txs) => FetchResult::Success(txs),
                     Err(e) => FetchResult::Error(format!("{:#}", e)),
                 });
                 ctx.request_repaint();
@@ -981,105 +1232,127 @@ impl App {
             self.tx_state.is_loading = false;
 
             match result {
-                FetchResult::Success(tx) => {
-                    // Compute hashes from the fetched transaction using validate_safe_tx_hash
-                    match compute_hashes_from_api_tx(
-                        &self.safe_context.chain_name,
-                        &self.safe_context.safe_address,
-                        &self.safe_context.safe_version,
-                        &tx,
-                    ) {
-                        Ok((hashes, mismatch)) => {
-                            // Add hash mismatch to warnings if present
-                            if let Some(m) = mismatch {
-                                self.tx_state.warnings.argument_mismatches.push(m);
-                            }
-                            self.tx_state.hashes = Some(hashes);
-                        }
-                        Err(e) => {
-                            self.tx_state.error = Some(format!("Hash computation failed: {:#}", e));
-                        }
+                FetchResult::Success(txs) => {
+                    if txs.is_empty() {
+                        self.tx_state.error =
+                            Some("No transaction found for the specified nonce".to_string());
+                        return;
                     }
 
-                    // Get warnings using check_suspicious_content (via get_warnings_from_api_tx)
-                    let chain_id = ChainId::of(&self.safe_context.chain_name).ok();
-                    match get_warnings_from_api_tx(&tx, chain_id) {
-                        Ok(warnings) => self.tx_state.warnings.union(warnings),
-                        Err(e) => {
-                            debug_log!("Warning computation failed: {:#}", e);
-                            self.tx_state.warnings_error = Some(format!("{:#}", e));
-                        }
+                    let mut sorted = txs;
+                    sorted.sort_by(|a, b| b.submission_date.cmp(&a.submission_date));
+                    self.tx_state.fetched_txs = sorted;
+                    let selected_index = self
+                        .tx_state
+                        .selected_tx_index
+                        .unwrap_or(0)
+                        .min(self.tx_state.fetched_txs.len() - 1);
+                    self.tx_state.selected_tx_index = Some(selected_index);
+
+                    if let Some(tx) = self.tx_state.fetched_txs.get(selected_index).cloned() {
+                        self.apply_fetched_tx(ctx, tx);
                     }
-
-                    // Validate against expected values if any were provided
-                    if self.tx_state.expected.has_values() {
-                        self.tx_state.expected.result =
-                            Some(expected::validate_against_api(&tx, &self.tx_state.expected));
-                    }
-
-                    // Initialize calldata decode
-                    debug_log!("Parsing calldata: {} bytes", tx.data.len());
-                    let decode_state = decode::parse_initial(&tx.data, tx.data_decoded.as_ref());
-                    debug_log!(
-                        "Decode kind: {:?}, selector: {}",
-                        match &decode_state.kind {
-                            TransactionKind::Empty => "Empty",
-                            TransactionKind::Single(_) => "Single",
-                            TransactionKind::MultiSend(_) => "MultiSend",
-                            TransactionKind::Unknown => "Unknown",
-                        },
-                        decode_state.selector
-                    );
-                    // Determine what verification to trigger
-                    let verification_action = match &decode_state.kind {
-                        TransactionKind::Single(_) if !decode_state.selector.is_empty() => {
-                            Some(("single", decode_state.selector.clone(), tx.data.clone(), 0))
-                        }
-                        TransactionKind::MultiSend(multi) => Some((
-                            "multi",
-                            String::new(),
-                            String::new(),
-                            multi.transactions.len(),
-                        )),
-                        _ => None,
-                    };
-
-                    self.tx_state.decode = Some(decode_state);
-
-                    // Trigger verification based on transaction type
-                    if let Some((kind, selector, data, tx_count)) = verification_action {
-                        match kind {
-                            "single" => {
-                                debug_log!("Triggering 4byte lookup for selector: {}", selector);
-                                self.trigger_decode_lookup(ctx, &selector, &data);
-                            }
-                            "multi" => {
-                                debug_log!(
-                                    "Triggering bulk verification for {} transactions",
-                                    tx_count
-                                );
-                                // Update verification state
-                                if let Some(ref mut decode) = self.tx_state.decode {
-                                    if let TransactionKind::MultiSend(ref mut multi) = decode.kind {
-                                        multi.verification_state =
-                                            decode::VerificationState::InProgress {
-                                                total: tx_count,
-                                            };
-                                    }
-                                }
-                                self.trigger_multisend_bulk_verify(ctx);
-                            }
-                            _ => {}
-                        }
-                    }
-
-                    self.tx_state.fetched_tx = Some(tx);
                 }
                 FetchResult::Error(e) => {
                     self.tx_state.error = Some(e);
                 }
             }
         }
+    }
+
+    fn apply_fetched_tx(&mut self, ctx: &egui::Context, tx: SafeTransaction) {
+        self.tx_state.error = None;
+        self.tx_state.hashes = None;
+        self.tx_state.warnings = SafeWarnings::new();
+        self.tx_state.warnings_error = None;
+        self.tx_state.decode = None;
+        self.tx_state.show_full_data = false;
+        self.tx_state.expected.clear_result();
+
+        // Compute hashes from the fetched transaction using validate_safe_tx_hash
+        match compute_hashes_from_api_tx(
+            &self.safe_context.chain_name,
+            &self.safe_context.safe_address,
+            &self.safe_context.safe_version,
+            &tx,
+        ) {
+            Ok((hashes, mismatch)) => {
+                // Add hash mismatch to warnings if present
+                if let Some(m) = mismatch {
+                    self.tx_state.warnings.argument_mismatches.push(m);
+                }
+                self.tx_state.hashes = Some(hashes);
+            }
+            Err(e) => {
+                self.tx_state.error = Some(format!("Hash computation failed: {:#}", e));
+            }
+        }
+
+        // Get warnings using check_suspicious_content (via get_warnings_from_api_tx)
+        let chain_id = ChainId::of(&self.safe_context.chain_name).ok();
+        match get_warnings_from_api_tx(&tx, chain_id) {
+            Ok(warnings) => self.tx_state.warnings.union(warnings),
+            Err(e) => {
+                debug_log!("Warning computation failed: {:#}", e);
+                self.tx_state.warnings_error = Some(format!("{:#}", e));
+            }
+        }
+
+        // Validate against expected values if any were provided
+        if self.tx_state.expected.has_values() {
+            self.tx_state.expected.result =
+                Some(expected::validate_against_api(&tx, &self.tx_state.expected));
+        }
+
+        // Initialize calldata decode
+        debug_log!("Parsing calldata: {} bytes", tx.data.len());
+        let decode_state = decode::parse_initial(&tx.data, tx.data_decoded.as_ref());
+        debug_log!(
+            "Decode kind: {:?}, selector: {}",
+            match &decode_state.kind {
+                TransactionKind::Empty => "Empty",
+                TransactionKind::Single(_) => "Single",
+                TransactionKind::MultiSend(_) => "MultiSend",
+                TransactionKind::Unknown => "Unknown",
+            },
+            decode_state.selector
+        );
+        // Determine what verification to trigger
+        let verification_action = match &decode_state.kind {
+            TransactionKind::Single(_) if !decode_state.selector.is_empty() => {
+                Some(("single", decode_state.selector.clone(), tx.data.clone(), 0))
+            }
+            TransactionKind::MultiSend(multi) => {
+                Some(("multi", String::new(), String::new(), multi.transactions.len()))
+            }
+            _ => None,
+        };
+
+        self.tx_state.decode = Some(decode_state);
+
+        // Trigger verification based on transaction type
+        if let Some((kind, selector, data, tx_count)) = verification_action {
+            match kind {
+                "single" => {
+                    debug_log!("Triggering 4byte lookup for selector: {}", selector);
+                    self.trigger_decode_lookup(ctx, &selector, &data);
+                }
+                "multi" => {
+                    debug_log!("Triggering bulk verification for {} transactions", tx_count);
+                    // Update verification state
+                    if let Some(ref mut decode) = self.tx_state.decode {
+                        if let TransactionKind::MultiSend(ref mut multi) = decode.kind {
+                            multi.verification_state =
+                                decode::VerificationState::InProgress { total: tx_count };
+                        }
+                    }
+                    self.trigger_multisend_bulk_verify(ctx);
+                }
+                _ => {}
+            }
+        }
+
+        self.tx_state.fetched_tx = Some(tx);
     }
 
     fn check_decode_result(&mut self) {

--- a/crates/rusty-safe/src/app.rs
+++ b/crates/rusty-safe/src/app.rs
@@ -312,7 +312,7 @@ impl App {
                 }
             }
 
-            // Show latest nonce info
+            // Show latest nonce info and pending count
             if let Some(ref info) = self.safe_info {
                 if ui
                     .small_button(format!("⟳ Latest: {}", info.nonce))
@@ -324,6 +324,19 @@ impl App {
                         self.tx_state.nonce = (info.nonce - 1).to_string();
                     } else {
                         self.tx_state.nonce = "0".to_string();
+                    }
+                }
+
+                // Show pending nonce count if available
+                if let Some(pending_count) = info.pending_nonce_count {
+                    if pending_count > 0 {
+                        if ui
+                            .small_button(format!("⏳ Pending: {}", pending_count))
+                            .on_hover_text("Click to set nonce to pending count")
+                            .clicked()
+                        {
+                            self.tx_state.nonce = pending_count.to_string();
+                        }
                     }
                 }
             }

--- a/crates/rusty-safe/src/app.rs
+++ b/crates/rusty-safe/src/app.rs
@@ -373,7 +373,7 @@ impl App {
 
         if self.tx_state.fetched_txs.len() > 1 {
             ui.add_space(10.0);
-            ui::section_header(ui, "Select Transaction");
+            ui::section_header(ui, &format!("Select Transaction for Nonce: {}", self.tx_state.nonce));
             ui::warning_banner(
                 ui,
                 "Multiple transactions found for this nonce. Safe API keeps all proposals with the same nonce (replacements/cancellations). Select one to verify.",

--- a/crates/rusty-safe/src/decode/ui.rs
+++ b/crates/rusty-safe/src/decode/ui.rs
@@ -592,7 +592,7 @@ fn render_multisend_tx(
                     ui.end_row();
 
                     ui.label("Value:");
-                    ui.label(format!("{} wei", tx.value));
+                    ui.label(crate::ui::format_wei_value(&tx.value));
                     ui.end_row();
 
                     ui.label("Operation:");
@@ -994,7 +994,7 @@ fn render_offline_multisend_tx(
                     ui.end_row();
 
                     ui.label("Value:");
-                    ui.label(format!("{} wei", tx.value));
+                    ui.label(crate::ui::format_wei_value(&tx.value));
                     ui.end_row();
 
                     ui.label("Operation:");

--- a/crates/rusty-safe/src/state.rs
+++ b/crates/rusty-safe/src/state.rs
@@ -287,6 +287,8 @@ pub struct TxVerifyState {
     pub decode: Option<DecodedTransaction>,
     pub show_full_data: bool,
     pub fetched_tx: Option<SafeTransaction>,
+    pub fetched_txs: Vec<SafeTransaction>,
+    pub selected_tx_index: Option<usize>,
     pub hashes: Option<ComputedHashes>,
     pub warnings: SafeWarnings,
     /// Set when warnings couldn't be computed due to parse errors
@@ -298,6 +300,8 @@ pub struct TxVerifyState {
 impl TxVerifyState {
     pub fn clear_results(&mut self) {
         self.fetched_tx = None;
+        self.fetched_txs.clear();
+        self.selected_tx_index = None;
         self.hashes = None;
         self.warnings = SafeWarnings::new();
         self.warnings_error = None;

--- a/crates/rusty-safe/src/ui.rs
+++ b/crates/rusty-safe/src/ui.rs
@@ -390,6 +390,26 @@ struct UintPopupState {
     decimals: u8,
 }
 
+/// Format wei value with ETH equivalent if large enough
+pub fn format_wei_value(wei: &str) -> String {
+    let trimmed = wei.trim();
+    if trimmed.is_empty() || trimmed == "0" {
+        return "0 wei".to_string();
+    }
+
+    // If value is large enough to show ETH equivalent (> 0.001 ETH = 1e15 wei)
+    if trimmed.len() > 15 {
+        let eth = format_uint_with_decimals(trimmed, 18);
+        format!("{} wei ({} ETH)", add_thousand_separators(trimmed), eth)
+    } else if trimmed.len() > 9 {
+        // Show Gwei for medium values
+        let gwei = format_uint_with_decimals(trimmed, 9);
+        format!("{} wei ({} Gwei)", add_thousand_separators(trimmed), gwei)
+    } else {
+        format!("{} wei", add_thousand_separators(trimmed))
+    }
+}
+
 /// Check if a value looks like a large uint (numeric, no decimals, > 1e6)
 pub fn is_large_uint(value: &str) -> bool {
     let trimmed = value.trim();

--- a/e2e/tests/capture.spec.ts
+++ b/e2e/tests/capture.spec.ts
@@ -46,23 +46,23 @@ test('capture with transaction data', async ({ page }) => {
   await canvas.click({ position: { x: 127, y: 210 } });
   await page.waitForTimeout(500);
   await page.keyboard.press('Control+a');
-  await page.keyboard.type('0x595362A906a0B4e90AEe1430b1f80FDDe2bE80de', { delay: 3 });
+  await page.keyboard.type('0x7DC3B586d4f3Df925A707cD4ffa7C8f4C74C7498', { delay: 3 });
   await page.waitForTimeout(500);
 
   // Click Fetch Details
   await canvas.click({ position: { x: 70, y: 290 } });
   await page.waitForTimeout(4000);
 
-  // Enter Nonce
-  await canvas.click({ position: { x: 430, y: 147 } });
+  // Enter Nonce - click on the nonce input field (adjusted for new layout with separator)
+  await canvas.click({ position: { x: 480, y: 185 } });
   await page.waitForTimeout(300);
   await page.keyboard.press('Control+a');
-  await page.keyboard.type('5');
+  await page.keyboard.type('188');
   await page.waitForTimeout(500);
 
-  // Click Fetch & Verify
-  await canvas.click({ position: { x: 352, y: 222 } });
-  await page.waitForTimeout(6000);
+  // Click Fetch & Verify button (below the collapsed "Verify Expected Values")
+  await canvas.click({ position: { x: 390, y: 262 } });
+  await page.waitForTimeout(12000);
 
   // Scroll to see all verification results
   await canvas.click({ position: { x: 640, y: 400 } });


### PR DESCRIPTION
## Summary

This PR adds support for multiple transactions per nonce and includes several UX improvements for the transaction verification flow.

### Features
- **Multiple transactions per nonce**: The app now fetches and displays all transactions sharing the same nonce (e.g., replacement transactions, competing proposals)
- **Transaction selector dropdown**: When multiple transactions exist for a nonce, users can select which one to verify
- **Pending nonce button**: Quick access to set nonce to the pending transaction count
- **Auto-fetch on "Fetch Details"**: Automatically fetches transaction data when clicking the Fetch Details button
- **Improved datetime formatting**: Human-readable date/time format for submission and execution timestamps
- **Styled button helpers**: Consistent button styling with wei value formatting utilities

### Fixes
- Eliminated duplicate transaction fetch when clicking Fetch Details
- Reduced auto-fetch delay from 300ms to 50ms for snappier UX
- Fixed nonce button to set `pending_count - 1` (the actual pending nonce)
- Simplified nonce button hover text for consistency
- Fixed execution date formatting to match submission date format

### Changes
- `crates/rusty-safe/src/app.rs` - Multi-tx state management, auto-fetch logic, nonce buttons
- `crates/rusty-safe/src/hasher.rs` - API changes for fetching multiple transactions
- `crates/rusty-safe/src/state.rs` - New state fields for multi-tx support
- `crates/rusty-safe/src/ui.rs` - Button styling helpers and wei formatting
- `crates/rusty-safe/src/decode/ui.rs` - Minor formatting fixes
- `e2e/tests/capture.spec.ts` - Updated test coordinates for new UI layout

## Test plan
- [x] Verify transaction fetch works for Safes with single transaction at a nonce
- [x] Verify transaction selector appears when multiple transactions share a nonce
- [x] Verify switching between transactions updates the verification display
- [x] Verify pending nonce button shows correct count and sets correct nonce
- [x] Verify auto-fetch triggers on Fetch Details click
- [x] Verify datetime formatting is readable
- [x] Run `cargo test` - all tests pass
- [x] Run `cargo clippy` - no errors